### PR TITLE
Post to topics and threads

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,9 +3,9 @@ name: docker-build
 on:
   release:
     types: [published] 
+  push:
     tags:
       - 'v*'
-  push:
     branches:
       - telegraf-v4
   schedule:
@@ -23,15 +23,16 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          # list of Doccker images to use as base name for tags
           images:
             lorcas/docker-telegram-notifier
-          # generate Docker tags based on the following events/attributes
+          # Modified tags configuration to handle beta versions
           tags: |
             type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=semver,pattern={{version}},enable=${{ !contains(github.ref, '-beta') }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(github.ref, '-beta') }}
+            type=semver,pattern={{major}},enable=${{ !contains(github.ref, '-beta') }}
+            # Add specific handling for beta versions
+            type=match,pattern=v\d+\.\d+\.\d+-beta\.\d+,group=0
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/README.md
+++ b/README.md
@@ -76,6 +76,27 @@ By default notifier connects to a local docker instance (don't forget to specify
 Notifier accepts usual `DOCKER_HOST` and `DOCKER_CERT_PATH` environment variables to specify remote instance. For http endpoint you need to specify only `--env DOCKER_HOST=tcp://example.com:2375` (make sure to keep such instances behind the firewall). For https, you'll also need to mount a volume with https certificates that contains `ca.pem`, `cert.pem`, and `key.pem`: `--env DOCKER_HOST=tcp://example.com:2376 --env DOCKER_CERT_PATH=/certs --volume $(pwd):/certs`
 Tutorial on how to generate docker certs can be found [here](https://docs.docker.com/engine/security/https/)
 
+## Container-Specific Notifications
+
+You can configure different Telegram channels and threads/topics for specific containers using Docker labels:
+
+```yaml
+services:
+  example:
+    image: hello-world
+    labels:
+      # Monitor control
+      telegram-notifier.monitor: true
+      
+      # Channel override (optional)
+      telegram-notifier.chat-id: "-100123456789"
+      
+      # Thread/Topic override (optional - use only one)
+      telegram-notifier.topic-id: "12345"
+      telegram-notifier.thread-id: "12345"
+```
+
+If these labels are not specified, the container will use the global settings from the notifier's environment variables.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -96,20 +96,24 @@ If you encounter any issues, please feel free to contribute by fixing them and o
 
 Here are some variables available to customize the notification messages:
 
-* `${e.Actor.Attributes.name}` = Docker container Name
-* `${e.Actor.Attributes.container}` = Docker container ID
-* `${e.Actor.Attributes.docker.network.internal}` = Docker Network Internal
-* `${e.Actor.Attributes.healthcheck.status}` = Docker container Healthcheck Status
-* `${e.Actor.Attributes.image}` = Docker container Image used
-* `${e.Actor.Attributes.maintainer}` = Docker container Maintainer
-* `${e.Actor.Attributes.signal}` = Docker container Exit Signal
-* `${e.Actor.Attributes.exitCode` = Docker container Exit Code
+| Variable | Description |
+| -------- | ----------- |
+| `${e.Actor.Attributes.name}` | Docker container Name |
+| `${e.Actor.Attributes.container}` | Docker container ID |
+| `${e.Actor.Attributes.docker.network.internal}` | Docker Network Internal |
+| `${e.Actor.Attributes.healthcheck.status}` | Docker container Healthcheck Status |
+| `${e.Actor.Attributes.image}` | Docker container Image used |
+| `${e.Actor.Attributes.maintainer}` | Docker container Maintainer |
+| `${e.Actor.Attributes.signal}` | Docker container Exit Signal |
+| `${e.Actor.Attributes.exitCode` | Docker container Exit Code |
 
-\+ These are only available if the container was started using `docker-compose.yaml`
-* `${e.Actor.Attributes.com.docker.compose.project}` = Compose Project Name
-* `${e.Actor.Attributes.com.docker.compose.service}` = Compose Service Name
-* `${e.Actor.Attributes.com.docker.compose.version}` = Compose Version
-* `${e.Actor.Attributes.com.docker.compose.container-number}` = Compose container Number
+The following are only available if the container was started using `docker-compose.yaml`
+| Variable | Description |
+| -------- | ----------- |
+| `${e.Actor.Attributes.com.docker.compose.project}` | Compose Project Name |
+| `${e.Actor.Attributes.com.docker.compose.service}` | Compose Service Name |
+| `${e.Actor.Attributes.com.docker.compose.version}` | Compose Version |
+| `${e.Actor.Attributes.com.docker.compose.container-number}` | Compose container Number |
 
 ## Blacklist and Whitelist
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you encounter any issues, please feel free to contribute by fixing them and o
     docker run -d \
         --env TELEGRAM_NOTIFIER_BOT_TOKEN=token \
         --env TELEGRAM_NOTIFIER_CHAT_ID=chat_id \
-        --env TELEGRAM_NOTIFIER_THREAD_ID=thread_id \
+        --env TELEGRAM_NOTIFIER_TOPIC_ID=topic_id \
         --volume /var/run/docker.sock:/var/run/docker.sock:ro \
         --hostname my_host \
         lorcas/docker-telegram-notifier
@@ -38,8 +38,10 @@ If you encounter any issues, please feel free to contribute by fixing them and o
         environment:
           # How to create bot: https://core.telegram.org/bots#3-how-do-i-create-a-bot
           # How to get chat id: https://stackoverflow.com/questions/32423837/telegram-bot-how-to-get-a-group-chat-id/32572159#32572159
-          TELEGRAM_NOTIFIER_BOT_TOKEN:
+          TELEGRAM_NOTIFIER_BOT_TOKEN: 
           TELEGRAM_NOTIFIER_CHAT_ID:
+          # One of the following two can be used, but not both
+          TELEGRAM_NOTIFIER_TOPIC_ID:
           TELEGRAM_NOTIFIER_THREAD_ID:
           # optional args
           # ONLY_WHITELIST: true

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ If you encounter any issues, please feel free to contribute by fixing them and o
     docker run -d \
         --env TELEGRAM_NOTIFIER_BOT_TOKEN=token \
         --env TELEGRAM_NOTIFIER_CHAT_ID=chat_id \
+        --env TELEGRAM_NOTIFIER_THREAD_ID=thread_id \
         --volume /var/run/docker.sock:/var/run/docker.sock:ro \
         --hostname my_host \
         lorcas/docker-telegram-notifier
@@ -39,6 +40,7 @@ If you encounter any issues, please feel free to contribute by fixing them and o
           # How to get chat id: https://stackoverflow.com/questions/32423837/telegram-bot-how-to-get-a-group-chat-id/32572159#32572159
           TELEGRAM_NOTIFIER_BOT_TOKEN:
           TELEGRAM_NOTIFIER_CHAT_ID:
+          TELEGRAM_NOTIFIER_THREAD_ID:
           # optional args
           # ONLY_WHITELIST: true
           # DOCKER_HOST: tcp://example.com:2376 # http/https is detected by port number

--- a/telegram.js
+++ b/telegram.js
@@ -3,7 +3,10 @@ const { Telegram } = require('telegraf');
 class TelegramClient {
   constructor() {
     this.telegram = new Telegram(process.env.TELEGRAM_NOTIFIER_BOT_TOKEN);
-    this.threadId = process.env.TELEGRAM_NOTIFIER_TOPIC_ID || process.env.TELEGRAM_NOTIFIER_THREAD_ID || null;
+    this.threadId = 
+      process.env.TELEGRAM_NOTIFIER_TOPIC_ID || 
+      process.env.TELEGRAM_NOTIFIER_THREAD_ID || 
+      null;
   }
 
   send(message) {

--- a/telegram.js
+++ b/telegram.js
@@ -9,31 +9,38 @@ class TelegramClient {
       null;
   }
 
-  send(message) {
+  async send(message, overrides = {}) {
     const options = {
       parse_mode: 'HTML',
       disable_web_page_preview: true
     };
 
-    if (this.threadId) {
-      options.message_thread_id = parseInt(this.threadId);
+    const threadId = overrides.threadId || this.threadId;
+    if (threadId) {
+      options.message_thread_id = parseInt(threadId);
     }
 
+    const chatId = overrides.chatId || process.env.TELEGRAM_NOTIFIER_CHAT_ID;
+
     return this.telegram.sendMessage(
-      process.env.TELEGRAM_NOTIFIER_CHAT_ID,
+      chatId,
       message,
       options
     );
   }
 
-  sendError(e) {
+  async sendError(e, overrides = {}) {
     const options = {};
-    if (this.threadId) {
-      options.message_thread_id = parseInt(this.threadId);
+    
+    const threadId = overrides.threadId || this.threadId;
+    if (threadId) {
+      options.message_thread_id = parseInt(threadId);
     }
 
+    const chatId = overrides.chatId || process.env.TELEGRAM_NOTIFIER_CHAT_ID;
+
     return this.telegram.sendMessage(
-      process.env.TELEGRAM_NOTIFIER_CHAT_ID,
+      chatId,
       `Error: ${e}`,
       options
     );

--- a/telegram.js
+++ b/telegram.js
@@ -3,7 +3,7 @@ const { Telegram } = require('telegraf');
 class TelegramClient {
   constructor() {
     this.telegram = new Telegram(process.env.TELEGRAM_NOTIFIER_BOT_TOKEN);
-    this.threadId = process.env.TELEGRAM_THREAD_ID || null;
+    this.threadId = process.env.TELEGRAM_NOTIFIER_THREAD_ID || null;
   }
 
   send(message) {

--- a/telegram.js
+++ b/telegram.js
@@ -3,23 +3,36 @@ const { Telegram } = require('telegraf');
 class TelegramClient {
   constructor() {
     this.telegram = new Telegram(process.env.TELEGRAM_NOTIFIER_BOT_TOKEN);
+    this.threadId = process.env.TELEGRAM_THREAD_ID || null;
   }
 
   send(message) {
+    const options = {
+      parse_mode: 'HTML',
+      disable_web_page_preview: true
+    };
+
+    if (this.threadId) {
+      options.message_thread_id = parseInt(this.threadId);
+    }
+
     return this.telegram.sendMessage(
       process.env.TELEGRAM_NOTIFIER_CHAT_ID,
       message,
-      { 
-        parse_mode: 'HTML',
-        disable_web_page_preview: true
-      }
+      options
     );
   }
 
   sendError(e) {
+    const options = {};
+    if (this.threadId) {
+      options.message_thread_id = parseInt(this.threadId);
+    }
+
     return this.telegram.sendMessage(
-        process.env.TELEGRAM_NOTIFIER_CHAT_ID,
-        `Error: ${e}`,
+      process.env.TELEGRAM_NOTIFIER_CHAT_ID,
+      `Error: ${e}`,
+      options
     );
   }
 

--- a/telegram.js
+++ b/telegram.js
@@ -3,7 +3,7 @@ const { Telegram } = require('telegraf');
 class TelegramClient {
   constructor() {
     this.telegram = new Telegram(process.env.TELEGRAM_NOTIFIER_BOT_TOKEN);
-    this.threadId = process.env.TELEGRAM_NOTIFIER_THREAD_ID || null;
+    this.threadId = process.env.TELEGRAM_NOTIFIER_TOPIC_ID || process.env.TELEGRAM_NOTIFIER_THREAD_ID || null;
   }
 
   send(message) {


### PR DESCRIPTION
This branch allows the telegram-notifier to send messages directly to topics and threads. To use it one of the following environment variables can be set:

```yaml
TELEGRAM_NOTIFIER_TOPIC_ID:
TELEGRAM_NOTIFIER_THREAD_ID:
```

Telegram does not recognise any difference in the two, but this should make it easier to understand for us humans.

This also contains changes by @oliveratgithub, who enhanced connection messages and documented how to create custom templates.