### PR TITLE
Improved how-to customizing notification messages in README

### DIFF
--- a/app.js
+++ b/app.js
@@ -58,7 +58,7 @@ async function sendVersion() {
     type: info.OSType,
     architecture: info.Architecture,
     cpu: info.NCPU,
-    memory: (info.MemTotal / (1024 * 1024)).toFixed(2) + 'MB',
+    memory: Math.floor(info.MemTotal / (1024 * 1024)) + ' MB',
     version: version.Version
   });
   console.log(text, "\n");


### PR DESCRIPTION
### `app.js` adjustments
* Small formatting change of the host memory value-variable

### `README.md` update
* Moved section `Notification messages customization` to bottom of README
* Corrected the documentation of default variables - and fixed how to reference docker-compose vars
* Added an example code-snippet for clarity
* Added a new sub-section: how-to leverage custom container labels to include in Telegram notifications
