### PR TITLE
Improves Telegram Bot API sendMessage to group chats which use Topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This Docker container provides a Telegram integration to notify you about Docker events. It can notify you when a container starts, stops (including details about exit codes), restarts, and when the healthcheck status of a Docker container changes. You have the flexibility to customize these notifications by [modifying the `templates.js` file](#3-notification-messages-customization).
 
-This fork was created to address security vulnerabilities and add support for 
+This fork was created to address security vulnerabilities and add support for
 - `linux/arm64` and
 - `linux/arm/v7` in addition to
 - `linux/amd64`.
@@ -31,7 +31,7 @@ If you encounter any issues, please feel free to contribute by fixing them and o
 - [Credits](#credits)
 
 
-## 1. Basic setup  
+## 1. Basic setup
 
 1. **Set up a Telegram bot**
 
@@ -64,7 +64,7 @@ If you encounter any issues, please feel free to contribute by fixing them and o
     ```
 
 3. **Add a healthcheck to your container** (optional)
-   
+
     ```yaml
     example:
       image: hello-world
@@ -155,8 +155,15 @@ services:
       telegram-notifier.chat-id: "-100123456789"
       # Thread/Topic override (optional - use only one)
       telegram-notifier.topic-id: "12345"
+      #                         : "false" # would explicitely override to use NONE
       telegram-notifier.thread-id: "12345"
+      #                          : "" # would also explicitely override to use NONE
 ```
+
+> [!IMPORTANT]
+> When leaving away a `.topic-id` / `.thread-id` label, but having one defined globally as per [Topics and Threads](#21-topics-and-threads), then that will be **used automatically as fallback**.
+> If that is unintended, you have to explicitely set the label to EMPTY (or `false`).
+> - Example scenario: when for example the per container `chat-id` differs from the global, and has NO Topics / Threads support.
 
 <details>
 <summary>
@@ -181,7 +188,7 @@ services:
   telegram-notifier:
     volumes:
       # disable for remote ONLY monitoring
-      # - /var/run/docker.sock:/var/run/docker.sock:ro 
+      # - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./certs:/certs # for remote instance
     environment:
       DOCKER_HOST: tcp://example.com:2376 # http/https is detected by port number

--- a/app.js
+++ b/app.js
@@ -11,11 +11,11 @@ async function sendEvent(event) {
   const template = templates[`${event.Type}_${event.Action}`];
   if (template) {
     const attributes = event.Actor?.Attributes || {};
-    
+
     // Check monitoring status
     const monitorLabel = attributes['telegram-notifier.monitor'];
-    const shouldMonitor = monitorLabel === undefined ? 
-      undefined : 
+    const shouldMonitor = monitorLabel === undefined ?
+      undefined :
       monitorLabel.toLowerCase().trim() !== 'false';
 
     if (shouldMonitor || !ONLY_WHITELIST && shouldMonitor !== false) {
@@ -29,9 +29,14 @@ async function sendEvent(event) {
       }
 
       // Only add threadId if explicitly set via label
-      const labelThreadId = attributes['telegram-notifier.topic-id'] || 
-                            attributes['telegram-notifier.thread-id'];
-      if (labelThreadId) {
+      const labelTopicId = attributes['telegram-notifier.topic-id'];
+      const labelThreadId = attributes['telegram-notifier.thread-id'];
+      if (labelTopicId) {
+        // Topic ID: set is_topic_message=true for Telegram Groups with Topics enabled
+        overrides.threadId = labelTopicId;
+        overrides.threadIsTopic = true;
+      } else if (labelThreadId) {
+        // Thread ID: don't set is_topic_message flag
         overrides.threadId = labelThreadId;
       }
 

--- a/app.js
+++ b/app.js
@@ -31,13 +31,31 @@ async function sendEvent(event) {
       // Only add threadId if explicitly set via label
       const labelTopicId = attributes['telegram-notifier.topic-id'];
       const labelThreadId = attributes['telegram-notifier.thread-id'];
-      if (labelTopicId) {
-        // Topic ID: set is_topic_message=true for Telegram Groups with Topics enabled
-        overrides.threadId = labelTopicId;
-        overrides.threadIsTopic = true;
-      } else if (labelThreadId) {
-        // Thread ID: don't set is_topic_message flag
-        overrides.threadId = labelThreadId;
+      // topic-id label exists - check if it's explicitly disabled
+      if (labelTopicId !== undefined) {
+        const isDisabled = labelTopicId === '' ||
+                           labelTopicId.toLowerCase() === 'false' ||
+                           labelTopicId === '0';
+        // Explicitly set to empty to disable thread/topic
+        if (isDisabled) {
+          overrides.threadId = '';
+        }
+        // Valid topic-id provided
+        else {
+          overrides.threadId = labelTopicId;
+          overrides.threadIsTopic = true;
+        }
+      }
+      // thread-id label exists - check if it's explicitly disabled
+      else if (labelThreadId !== undefined) {
+        const isDisabled = labelThreadId === '' ||
+                           labelThreadId.toLowerCase() === 'false' ||
+                           labelThreadId === '0';
+        if (isDisabled) {
+          overrides.threadId = '';
+        } else {
+          overrides.threadId = labelThreadId;
+        }
       }
 
       const attachment = template(event);

--- a/telegram.js
+++ b/telegram.js
@@ -3,9 +3,9 @@ const { Telegram } = require('telegraf');
 class TelegramClient {
   constructor() {
     this.telegram = new Telegram(process.env.TELEGRAM_NOTIFIER_BOT_TOKEN);
-    this.threadId = 
-      process.env.TELEGRAM_NOTIFIER_TOPIC_ID || 
-      process.env.TELEGRAM_NOTIFIER_THREAD_ID || 
+    this.threadId =
+      process.env.TELEGRAM_NOTIFIER_TOPIC_ID ||
+      process.env.TELEGRAM_NOTIFIER_THREAD_ID ||
       null;
   }
 
@@ -30,20 +30,41 @@ class TelegramClient {
   }
 
   async sendError(e, overrides = {}) {
-    const options = {};
-    
-    const threadId = overrides.threadId || this.threadId;
-    if (threadId) {
-      options.message_thread_id = parseInt(threadId);
-    }
+    const options = {
+      parse_mode: 'HTML',
+      disable_web_page_preview: true
+    };
 
     const chatId = overrides.chatId || process.env.TELEGRAM_NOTIFIER_CHAT_ID;
 
-    return this.telegram.sendMessage(
-      chatId,
-      `Error: ${e}`,
-      options
-    );
+    // Extract error details from TelegramError response JSON
+    const errorCode = e.response?.error_code || '0';
+    const errorDescription = e.response?.description || e.message || 'Unknown error';
+    const failedMethod = e.on?.method || 'sendMessage';
+    const failedPayloadJson = JSON.stringify(e.on?.payload, null, 2);
+    let errorMessage = `[Error ${failedMethod}] ${errorCode} - ${errorDescription}\n<pre>${failedPayloadJson}</pre>`;
+
+    try {
+      // Try to send error WITHOUT the topic_id to avoid recursive errors
+      // This ensures the message reaches the chat even if topic_id is wrong
+      return await this.telegram.sendMessage(
+        chatId,
+        errorMessage,
+        options
+      );
+    } catch (fallbackError) {
+      // If even this fails, log to console only
+      console.error('Failed to send error notification to Telegram:', {
+        originalError: {
+          code: errorCode,
+          description: errorDescription,
+          chatId: chatId
+        },
+        fallbackError: fallbackError.message
+      });
+      // Re-throw so it's visible in logs
+      throw fallbackError;
+    }
   }
 
   check() {

--- a/telegram.js
+++ b/telegram.js
@@ -18,6 +18,9 @@ class TelegramClient {
     const threadId = overrides.threadId || this.threadId;
     if (threadId) {
       options.message_thread_id = parseInt(threadId);
+      if (overrides.threadIsTopic) {
+        options.is_topic_message = true;
+      }
     }
 
     const chatId = overrides.chatId || process.env.TELEGRAM_NOTIFIER_CHAT_ID;

--- a/telegram.js
+++ b/telegram.js
@@ -15,7 +15,12 @@ class TelegramClient {
       disable_web_page_preview: true
     };
 
-    const threadId = overrides.threadId || this.threadId;
+    // Check if threadId was explicitly provided in overrides (even if empty)
+    const threadId = 'threadId' in overrides
+      ? overrides.threadId
+      : this.threadId;
+
+    // Only set message_thread_id if threadId has a truthy value
     if (threadId) {
       options.message_thread_id = parseInt(threadId);
       if (overrides.threadIsTopic) {


### PR DESCRIPTION
Resolves luc-ass/docker-telegram-notifier#121 and luc-ass/docker-telegram-notifier#122

## 1) Improved `telegram-notifier.topic-id` label overrides (`sendEvent()`)
Successfully verified working using a Commit checkout on a local Docker stack.

## 2) Improved Error messages (`sendError()`)
Successfully verified working using a Commit checkout on a local Docker stack.

<img width="767" height="523" alt="Screenshot 2025-11-01 at 11 49 55" src="https://github.com/user-attachments/assets/079468bd-7b24-43cc-83a8-d8507693deb2" />
<img width="514" height="208" alt="Screenshot 2025-11-01 at 12 25 02" src="https://github.com/user-attachments/assets/7206e6d4-4f42-4de1-b2a1-1788b49240c3" />

## 3) Allows to explicitly use "no" Thread Id/Topic Id in overrides
This makes it now properly possible to send notifications for individual Docker services to other Chats which may not have/support Topics/Threads.

- Before that change, it used always to fallback and use the docker-telegram service's defined Topic/Thread Id, if such was set for the main Chat.