### PR TITLE
Fix the multi-arch image build (broken since October 2025)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      # Node 24 dropped 32-bit ARM, so a major bump of the base image silently
+      # breaks the linux/arm/v7 build. Major updates are a deliberate decision
+      # here and have to be made by hand, together with the platforms list in
+      # .github/workflows/docker-image.yml.
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM node:lts-slim
+# Pinned to 22-slim on purpose: node 24 dropped 32-bit ARM, so node:lts-slim
+# has no linux/arm/v7 manifest and the multi-arch build fails outright.
+# Do not move this to lts or 24 while linux/arm is in the platforms list.
+# Node 22 has security support until April 2027.
+FROM node:22-slim
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ This fork was created to address security vulnerabilities and add support for
 - `linux/arm/v7` in addition to
 - `linux/amd64`.
 
+> [!NOTE]
+> The image is built on `node:22-slim` rather than `node:lts-slim`. Node 24 dropped
+> support for 32-bit ARM, so tracking the `lts` tag would silently drop `linux/arm/v7`.
+> Node 22 receives security support until April 2027; `linux/arm/v7` support will be
+> reconsidered before then.
+
 If you encounter any issues, please feel free to contribute by fixing them and opening a [pull request](https://github.com/luc-ass/docker-telegram-notifier/pulls) or reporting a new [issue](https://github.com/luc-ass/docker-telegram-notifier/issues).
 
 <!-- omit in toc -->


### PR DESCRIPTION
The image build has failed on **every run since 27 October 2025 — 46 consecutive failures**, including every weekly scheduled rebuild. The release build for v1.4.11 failed for the same reason. `latest` on Docker Hub is still the image from October 2025 and carries the dependency tree that v1.4.11 was meant to fix.

## What broke

```
ERROR: failed to solve: node:lts-slim: failed to resolve source metadata
for docker.io/library/node:lts-slim: no match for platform in manifest: not found
```

Node 24 dropped support for 32-bit ARM, and the `lts` tag has since rolled from 22 to 24. `node:lts-slim` therefore no longer publishes a `linux/arm/v7` manifest:

| base image | platforms |
|---|---|
| `node:22-slim` | amd64, **arm/v7**, arm64, ppc64le |
| `node:24-slim` (= current `lts-slim`) | amd64, arm64, ppc64le |
| `node:lts-alpine` | amd64, arm64, s390x |

Since `linux/arm` is in the `platforms` list, one unresolvable platform fails the entire multi-arch build — amd64 and arm64 never get built either.

## The fix

Pin the base image to `node:22-slim`, which restores all three platforms. Node 22 has security support until April 2027, which leaves room to announce the eventual removal of `linux/arm/v7` rather than dropping it without warning — it is one of the stated reasons this fork exists.

Dependabot is configured to ignore major updates of the base image, because the next major bump would silently reintroduce exactly this failure. Minor and patch updates still come through. The Dockerfile carries a comment explaining the constraint, and the README documents it for users.

## Verification

`linux/arm/v7` was built locally under QEMU — the platform that has been failing. The base image resolves, `npm install` completes and `npm audit` reports no vulnerabilities.

## After merging

The v1.4.11 tag and release need to be recreated on the fixed commit; the existing one produced no image at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpQu4cAwjJddpMec8Agd4p