### PR TITLE
Harden the topic and error handling from #123

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,34 +28,20 @@ async function sendEvent(event) {
         overrides.chatId = labelChatId;
       }
 
-      // Only add threadId if explicitly set via label
+      // Only add threadId if explicitly set via label. topic-id wins over
+      // thread-id; an empty value, 'false' or '0' turns the globally
+      // configured topic off for this container, which is what you need when
+      // its chat has no topics at all.
       const labelTopicId = attributes['telegram-notifier.topic-id'];
       const labelThreadId = attributes['telegram-notifier.thread-id'];
-      // topic-id label exists - check if it's explicitly disabled
-      if (labelTopicId !== undefined) {
-        const isDisabled = labelTopicId === '' ||
-                           labelTopicId.toLowerCase() === 'false' ||
-                           labelTopicId === '0';
-        // Explicitly set to empty to disable thread/topic
-        if (isDisabled) {
-          overrides.threadId = '';
-        }
-        // Valid topic-id provided
-        else {
-          overrides.threadId = labelTopicId;
-          overrides.threadIsTopic = true;
-        }
-      }
-      // thread-id label exists - check if it's explicitly disabled
-      else if (labelThreadId !== undefined) {
-        const isDisabled = labelThreadId === '' ||
-                           labelThreadId.toLowerCase() === 'false' ||
-                           labelThreadId === '0';
-        if (isDisabled) {
-          overrides.threadId = '';
-        } else {
-          overrides.threadId = labelThreadId;
-        }
+      const labelValue = labelTopicId !== undefined ? labelTopicId : labelThreadId;
+
+      if (labelValue !== undefined) {
+        const value = labelValue.trim();
+        const isDisabled = value === '' ||
+                           value.toLowerCase() === 'false' ||
+                           value === '0';
+        overrides.threadId = isDisabled ? '' : value;
       }
 
       const attachment = template(event);

--- a/telegram.js
+++ b/telegram.js
@@ -23,9 +23,6 @@ class TelegramClient {
     // Only set message_thread_id if threadId has a truthy value
     if (threadId) {
       options.message_thread_id = parseInt(threadId);
-      if (overrides.threadIsTopic) {
-        options.is_topic_message = true;
-      }
     }
 
     const chatId = overrides.chatId || process.env.TELEGRAM_NOTIFIER_CHAT_ID;

--- a/telegram.js
+++ b/telegram.js
@@ -1,6 +1,19 @@
 const { Telegram } = require('telegraf');
 
 /**
+ * Messages are sent with parse_mode HTML, so every value interpolated into
+ * message text has to be escaped. Container names, image tags and custom
+ * labels are arbitrary strings: a single stray '<' makes Telegram reject the
+ * whole message.
+ */
+function escapeHtml(text) {
+  return String(text)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/**
  * Telegram expects message_thread_id to be a positive integer. parseInt on a
  * label like 'general' yields NaN, which is serialised as null and answered
  * with a 400 that says nothing about the actual mistake.
@@ -60,12 +73,24 @@ class TelegramClient {
 
     const chatId = overrides.chatId || process.env.TELEGRAM_NOTIFIER_CHAT_ID;
 
-    // Extract error details from TelegramError response JSON
+    // Extract error details from TelegramError response JSON. Errors that did
+    // not come from the Telegram API carry neither response nor on, so the
+    // method and payload are left out rather than mislabelled.
     const errorCode = e.response?.error_code || '0';
     const errorDescription = e.response?.description || e.message || 'Unknown error';
-    const failedMethod = e.on?.method || 'sendMessage';
-    const failedPayloadJson = JSON.stringify(e.on?.payload, null, 2);
-    let errorMessage = `[Error ${failedMethod}] ${errorCode} - ${errorDescription}\n<pre>${failedPayloadJson}</pre>`;
+    const failedMethod = e.on?.method;
+    const failedPayload = e.on?.payload;
+
+    let errorMessage = failedMethod
+      ? `[Error ${escapeHtml(failedMethod)}] ${escapeHtml(errorCode)} - ${escapeHtml(errorDescription)}`
+      : `[Error] ${escapeHtml(errorCode)} - ${escapeHtml(errorDescription)}`;
+
+    // The payload contains the original message text, which is our own HTML
+    // template output. Unescaped it would either be rendered instead of shown,
+    // or break the error report itself.
+    if (failedPayload !== undefined) {
+      errorMessage += `\n<pre>${escapeHtml(JSON.stringify(failedPayload, null, 2))}</pre>`;
+    }
 
     try {
       // Try to send error WITHOUT the topic_id to avoid recursive errors

--- a/telegram.js
+++ b/telegram.js
@@ -1,5 +1,15 @@
 const { Telegram } = require('telegraf');
 
+/**
+ * Telegram expects message_thread_id to be a positive integer. parseInt on a
+ * label like 'general' yields NaN, which is serialised as null and answered
+ * with a 400 that says nothing about the actual mistake.
+ */
+function parseThreadId(value) {
+  const id = Number.parseInt(String(value).trim(), 10);
+  return Number.isSafeInteger(id) && id > 0 ? id : null;
+}
+
 class TelegramClient {
   constructor() {
     this.telegram = new Telegram(process.env.TELEGRAM_NOTIFIER_BOT_TOKEN);
@@ -22,7 +32,15 @@ class TelegramClient {
 
     // Only set message_thread_id if threadId has a truthy value
     if (threadId) {
-      options.message_thread_id = parseInt(threadId);
+      const parsedThreadId = parseThreadId(threadId);
+      if (parsedThreadId === null) {
+        console.error(
+          `Ignoring invalid topic/thread id ${JSON.stringify(threadId)}: ` +
+          `expected a positive integer. Sending to the chat without a topic.`
+        );
+      } else {
+        options.message_thread_id = parsedThreadId;
+      }
     }
 
     const chatId = overrides.chatId || process.env.TELEGRAM_NOTIFIER_CHAT_ID;


### PR DESCRIPTION
Follow-up to #123, as announced in the review there. #123 solved the reported problem — this addresses three defects in it without taking anything away from the change.

## 1. `is_topic_message` is not a `sendMessage` parameter

Checked against `@telegraf/types`: the field appears only in `message.d.ts`, on the response object, documented as *"True, if the message is sent to a forum topic"*. It is not part of any method signature. Telegram ignores unknown parameters, so nothing was broken — but it wrote the assumption from #122 into the code. See #122 for the full answer.

The two label branches also did the same thing twice and collapse into one. The value is now trimmed, matching the monitor label a few lines above, so `" false "` disables the topic just like `"false"`.

## 2. Invalid thread ids no longer become `NaN`

`parseInt(threadId)` had no radix and no `NaN` check, so `topic-id: "general"` produced `message_thread_id: NaN`. That serialises to `null` and comes back as *"400: Bad Request: message thread not found"* — a message that points at the topic rather than at the label that is actually wrong. This is most likely the root cause behind #121.

An unusable id is now reported on the console, naming the offending value, and the notification goes to the chat without a topic rather than being lost.

## 3. HTML escaping in the error path

`sendError` sends with `parse_mode: HTML` and embeds the failed payload in a `<pre>` block. That payload carries the original message text — our own template output — so tags went out unescaped:

```
<pre>{
  "text": "▶️ <b>webserver</b> started\nImage: <code>nginx</code>",
  ...
}</pre>
```

At best Telegram renders the payload instead of showing it, so the report no longer says what was actually sent. At worst it fails to parse: the README encourages arbitrary text in custom labels, and one stray `<` is enough for a 400. The error path would then fail on the very error it is reporting.

Errors that did not come from the Telegram API carry neither `response` nor `on`, so the method and payload are now omitted instead of printing `undefined` and blaming `sendMessage` for, say, a dropped docker stream.

## Verification

Unit-level: 15 assertions over thread id handling, escaping, and non-Telegram errors.

End-to-end against a live docker daemon, with `telegraf` stubbed to record what would be sent:

| container | label | result |
|---|---|---|
| `t-default` | — | base chat, topic 42 |
| `t-off` | `topic-id=false` | base chat, no topic |
| `t-own` | `topic-id=" 777 "`, own chat-id | own chat, topic 777, trimmed |
| `t-bad` | `topic-id=general` | logged, no `NaN`, message still delivered |
| `t-mute` | `monitor=false` | nothing sent |

`is_topic_message` no longer appears in any outgoing call.

## Still open

The templates interpolate container names, image tags and custom labels into HTML unescaped. The escape helper added here is general enough to cover that, but doing it properly is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpQu4cAwjJddpMec8Agd4p