### PR TITLE
Keep the notifier from going silent

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,20 @@ const { ONLY_WHITELIST } = process.env;
 const docker = new Docker();
 const telegram = new TelegramClient();
 
+const RECONNECT_MIN_MS = 1000;
+const RECONNECT_MAX_MS = 60000;
+
+let stream = null;
+let reconnectTimer = null;
+let reconnectDelay = RECONNECT_MIN_MS;
+let shuttingDown = false;
+
+// `since` has one-second resolution and is inclusive, so a reconnect replays
+// the whole second we stopped in. Remember which events of that second were
+// already handled and drop them when they come back.
+let lastEventTime = null;
+let handledInLastSecond = new Set();
+
 async function sendEvent(event) {
   const template = templates[`${event.Type}_${event.Action}`];
   if (template) {
@@ -51,11 +65,80 @@ async function sendEvent(event) {
   }
 }
 
-async function sendEventStream() {
-  const eventStream = await docker.getEvents();
-  eventStream.pipe(JSONStream.parse())
-    .on('data', event => sendEvent(event).catch(handleError))
-    .on('error', handleError);
+function eventKey(event) {
+  return `${event.timeNano}|${event.Type}|${event.Action}|${event.Actor?.ID}`;
+}
+
+// Returns false for an event we already handled before a reconnect.
+function isNewEvent(event) {
+  if (typeof event.time !== 'number') return true;
+
+  if (lastEventTime === null || event.time > lastEventTime) {
+    lastEventTime = event.time;
+    handledInLastSecond = new Set([eventKey(event)]);
+    return true;
+  }
+  if (event.time < lastEventTime) return false;
+
+  const key = eventKey(event);
+  if (handledInLastSecond.has(key)) return false;
+  handledInLastSecond.add(key);
+  return true;
+}
+
+function scheduleReconnect(reason) {
+  if (shuttingDown || reconnectTimer) return;
+
+  if (stream) {
+    stream.destroy();
+    stream = null;
+  }
+
+  // Jitter keeps a fleet of notifiers from reconnecting in lockstep after a
+  // daemon restart.
+  const delay = Math.round(reconnectDelay * (1 + Math.random() * 0.25));
+  console.error(`${reason}. Reconnecting in ${Math.round(delay / 1000)}s.`);
+  reconnectDelay = Math.min(reconnectDelay * 2, RECONNECT_MAX_MS);
+
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null;
+    connectEventStream().catch(e => scheduleReconnect(`Reconnect failed: ${e.message}`));
+  }, delay);
+}
+
+async function connectEventStream() {
+  const options = {};
+  if (lastEventTime !== null) {
+    options.since = lastEventTime;
+  }
+
+  stream = await docker.getEvents(options);
+  reconnectDelay = RECONNECT_MIN_MS;
+  console.log(lastEventTime === null ?
+    "Listening for docker events." :
+    `Listening for docker events again, replaying from ${lastEventTime}.`);
+
+  stream.pipe(JSONStream.parse())
+    .on('data', event => {
+      if (isNewEvent(event)) sendEvent(event).catch(handleError);
+    })
+    .on('error', e => scheduleReconnect(`Could not parse the event stream: ${e.message}`));
+
+  // A docker restart ends the stream without an error. Without this the
+  // process kept running and silently stopped reporting anything.
+  stream.on('end', () => scheduleReconnect("The docker event stream ended"));
+  stream.on('close', () => scheduleReconnect("The docker event stream closed"));
+  stream.on('error', e => scheduleReconnect(`The docker event stream failed: ${e.message}`));
+}
+
+function shutdown(signal) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.log(`Received ${signal}, shutting down.`);
+
+  if (reconnectTimer) clearTimeout(reconnectTimer);
+  if (stream) stream.destroy();
+  process.exit(0);
 }
 
 async function sendVersion() {
@@ -75,8 +158,19 @@ async function sendVersion() {
 }
 
 async function main() {
-  await sendVersion();
-  await sendEventStream();
+  process.once('SIGTERM', () => shutdown('SIGTERM'));
+  process.once('SIGINT', () => shutdown('SIGINT'));
+
+  // Connect first. A failing start-up message must not cost us the event
+  // stream: main() rejected before the listener was ever set up, and the
+  // container then sat there doing nothing.
+  await connectEventStream();
+
+  try {
+    await sendVersion();
+  } catch (e) {
+    console.error("Could not send the start-up message:", e.message);
+  }
 }
 
 async function healthcheck() {

--- a/app.js
+++ b/app.js
@@ -1,3 +1,6 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 const Docker = require('dockerode');
 const TelegramClient = require('./telegram');
 const JSONStream = require('JSONStream');
@@ -7,10 +10,20 @@ const { ONLY_WHITELIST } = process.env;
 const docker = new Docker();
 const telegram = new TelegramClient();
 
+// The healthcheck runs as its own process and cannot see the state of the
+// event loop, so the listener leaves a heartbeat file behind instead. It is
+// refreshed while the stream is connected and the daemon answers, and goes
+// stale as soon as either stops being true.
+const HEARTBEAT_FILE = process.env.TELEGRAM_NOTIFIER_HEARTBEAT_FILE ||
+  path.join(os.tmpdir(), 'docker-telegram-notifier.heartbeat');
+const HEARTBEAT_INTERVAL_MS = 30000;
+const HEARTBEAT_MAX_AGE_MS = 90000;
+
 const RECONNECT_MIN_MS = 1000;
 const RECONNECT_MAX_MS = 60000;
 
 let stream = null;
+let heartbeatTimer = null;
 let reconnectTimer = null;
 let reconnectDelay = RECONNECT_MIN_MS;
 let shuttingDown = false;
@@ -86,9 +99,40 @@ function isNewEvent(event) {
   return true;
 }
 
+function writeHeartbeat() {
+  try {
+    fs.writeFileSync(HEARTBEAT_FILE, String(Date.now()));
+  } catch (e) {
+    console.error("Could not write the heartbeat file:", e.message);
+  }
+}
+
+function startHeartbeat() {
+  stopHeartbeat();
+  writeHeartbeat();
+  heartbeatTimer = setInterval(async () => {
+    try {
+      // An open stream is not proof on its own — a half-open socket still
+      // looks connected from here. Ask the daemon before refreshing.
+      await docker.ping();
+      writeHeartbeat();
+    } catch (e) {
+      console.error("Docker did not answer, heartbeat not refreshed:", e.message);
+    }
+  }, HEARTBEAT_INTERVAL_MS);
+}
+
+function stopHeartbeat() {
+  if (heartbeatTimer) {
+    clearInterval(heartbeatTimer);
+    heartbeatTimer = null;
+  }
+}
+
 function scheduleReconnect(reason) {
   if (shuttingDown || reconnectTimer) return;
 
+  stopHeartbeat();
   if (stream) {
     stream.destroy();
     stream = null;
@@ -114,6 +158,7 @@ async function connectEventStream() {
 
   stream = await docker.getEvents(options);
   reconnectDelay = RECONNECT_MIN_MS;
+  startHeartbeat();
   console.log(lastEventTime === null ?
     "Listening for docker events." :
     `Listening for docker events again, replaying from ${lastEventTime}.`);
@@ -137,7 +182,13 @@ function shutdown(signal) {
   console.log(`Received ${signal}, shutting down.`);
 
   if (reconnectTimer) clearTimeout(reconnectTimer);
+  stopHeartbeat();
   if (stream) stream.destroy();
+  try {
+    fs.unlinkSync(HEARTBEAT_FILE);
+  } catch (e) {
+    // Nothing to clean up.
+  }
   process.exit(0);
 }
 
@@ -173,6 +224,15 @@ async function main() {
   }
 }
 
+function heartbeatAge() {
+  try {
+    const written = Number.parseInt(fs.readFileSync(HEARTBEAT_FILE, 'utf8').trim(), 10);
+    return Number.isSafeInteger(written) ? Date.now() - written : null;
+  } catch (e) {
+    return null;
+  }
+}
+
 async function healthcheck() {
   try {
     await docker.version();
@@ -180,6 +240,21 @@ async function healthcheck() {
     console.error(e);
     console.error("Docker is unavailable");
     process.exit(101);
+  }
+
+  // Reaching the daemon is not the same as still listening to it. The stream
+  // can end while the daemon stays up, and that is the failure that used to
+  // go unnoticed.
+  const age = heartbeatAge();
+  if (age === null) {
+    console.error(`No heartbeat at ${HEARTBEAT_FILE}`);
+    console.error("Not listening for docker events");
+    process.exit(103);
+  }
+  if (age > HEARTBEAT_MAX_AGE_MS) {
+    console.error(`Heartbeat is ${Math.round(age / 1000)}s old, expected at most ${HEARTBEAT_MAX_AGE_MS / 1000}s`);
+    console.error("Not listening for docker events");
+    process.exit(103);
   }
 
   try {

--- a/telegram.js
+++ b/telegram.js
@@ -23,13 +23,89 @@ function parseThreadId(value) {
   return Number.isSafeInteger(id) && id > 0 ? id : null;
 }
 
+// Telegram accepts roughly 20 messages per minute into one group. A
+// crash-looping container produces far more than that, so sends are spaced
+// out instead of being fired as fast as docker reports them.
+const configuredInterval = Number.parseInt(process.env.TELEGRAM_NOTIFIER_SEND_INTERVAL_MS, 10);
+const SEND_INTERVAL_MS = Number.isSafeInteger(configuredInterval) && configuredInterval >= 0 ?
+  configuredInterval : 1000;
+
+// A burst that outruns the queue is dropped rather than kept in memory
+// forever: by the time a backlog this long drains, the notifications are of
+// no use anyway.
+const MAX_QUEUED = 200;
+const MAX_RATE_LIMIT_RETRIES = 3;
+
+// Every failed send used to produce another notification, so one bad topic id
+// could turn a restart loop into a stream of error messages.
+const ERROR_WINDOW_MS = 300000;
+const MAX_ERRORS_PER_WINDOW = 5;
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
 class TelegramClient {
   constructor() {
     this.telegram = new Telegram(process.env.TELEGRAM_NOTIFIER_BOT_TOKEN);
+    this.queue = Promise.resolve();
+    this.queued = 0;
+    this.lastSentAt = 0;
+    this.recentErrors = [];
+    this.suppressionAnnounced = false;
+    this.dropped = 0;
     this.threadId =
       process.env.TELEGRAM_NOTIFIER_TOPIC_ID ||
       process.env.TELEGRAM_NOTIFIER_THREAD_ID ||
       null;
+  }
+
+  // Runs tasks one at a time, never closer together than SEND_INTERVAL_MS.
+  enqueue(task) {
+    if (this.queued >= MAX_QUEUED) {
+      // One line per drop would bury the log during exactly the burst that
+      // caused it, so report the first drop and the total once it clears.
+      if (this.dropped === 0) {
+        console.error(`Send queue is full (${MAX_QUEUED} waiting), dropping notifications.`);
+      }
+      this.dropped++;
+      return Promise.resolve(null);
+    }
+
+    if (this.dropped > 0) {
+      console.error(`Send queue has room again, ${this.dropped} notification(s) were dropped.`);
+      this.dropped = 0;
+    }
+
+    this.queued++;
+    const run = this.queue.then(async () => {
+      const wait = SEND_INTERVAL_MS - (Date.now() - this.lastSentAt);
+      if (wait > 0) await sleep(wait);
+      try {
+        return await task();
+      } finally {
+        this.lastSentAt = Date.now();
+        this.queued--;
+      }
+    });
+
+    // The chain must survive a failed send, or nothing is ever sent again.
+    this.queue = run.catch(() => {});
+    return run;
+  }
+
+  // Honours the retry_after Telegram sends with a 429 instead of hammering it.
+  async withRateLimitRetry(call) {
+    for (let attempt = 0; ; attempt++) {
+      try {
+        return await call();
+      } catch (e) {
+        const retryAfter = e.response?.parameters?.retry_after;
+        if (retryAfter === undefined || attempt >= MAX_RATE_LIMIT_RETRIES) throw e;
+        console.error(`Rate limited by Telegram, retrying in ${retryAfter}s.`);
+        await sleep((retryAfter + 1) * 1000);
+      }
+    }
   }
 
   async send(message, overrides = {}) {
@@ -58,14 +134,36 @@ class TelegramClient {
 
     const chatId = overrides.chatId || process.env.TELEGRAM_NOTIFIER_CHAT_ID;
 
-    return this.telegram.sendMessage(
-      chatId,
-      message,
-      options
-    );
+    return this.enqueue(() => this.withRateLimitRetry(
+      () => this.telegram.sendMessage(chatId, message, options)
+    ));
+  }
+
+  // True while the error budget for the current window still has room.
+  mayReportError() {
+    const now = Date.now();
+    this.recentErrors = this.recentErrors.filter(at => now - at < ERROR_WINDOW_MS);
+
+    if (this.recentErrors.length >= MAX_ERRORS_PER_WINDOW) {
+      if (!this.suppressionAnnounced) {
+        console.error(
+          `More than ${MAX_ERRORS_PER_WINDOW} errors in ${ERROR_WINDOW_MS / 1000}s; ` +
+          `further error notifications are suppressed until the rate drops. ` +
+          `They are still written to the log.`
+        );
+        this.suppressionAnnounced = true;
+      }
+      return false;
+    }
+
+    this.recentErrors.push(now);
+    this.suppressionAnnounced = false;
+    return true;
   }
 
   async sendError(e, overrides = {}) {
+    if (!this.mayReportError()) return null;
+
     const options = {
       parse_mode: 'HTML',
       disable_web_page_preview: true
@@ -95,11 +193,9 @@ class TelegramClient {
     try {
       // Try to send error WITHOUT the topic_id to avoid recursive errors
       // This ensures the message reaches the chat even if topic_id is wrong
-      return await this.telegram.sendMessage(
-        chatId,
-        errorMessage,
-        options
-      );
+      return await this.enqueue(() => this.withRateLimitRetry(
+        () => this.telegram.sendMessage(chatId, errorMessage, options)
+      ));
     } catch (fallbackError) {
       // If even this fails, log to console only
       console.error('Failed to send error notification to Telegram:', {


### PR DESCRIPTION
Phase 3 of the overhaul: the failure modes where the container looks perfectly healthy and reports nothing.

## 1. The event stream never reconnected

`sendEventStream` had no `end`, `close` or `error` handler. When the stream ended — a docker daemon restart is enough — the process kept running and simply stopped reporting. Nothing in the container looked wrong. For a monitoring tool that is the worst failure there is: it does not tell you it stopped working.

The stream is now reopened with exponential backoff, one second up to a minute, with jitter so a fleet of notifiers does not reconnect in lockstep after a daemon restart.

**Events are no longer lost while disconnected.** The timestamp of the last handled event is passed back as `since`. That parameter has one-second resolution and is inclusive, so a reconnect replays the whole second we stopped in; events already handled in that second are remembered by a composite key and dropped when they come back. `timeNano` alone would not do — at ~1.79e18 it is above `Number.MAX_SAFE_INTEGER` and cannot be compared exactly.

## 2. The healthcheck could not see it

The healthcheck called `docker.version()` and `telegram.getMe()`. Both keep succeeding when the stream is gone, so the container stayed healthy while reporting nothing.

The healthcheck runs as its own process and cannot read the state of the event loop, so the listener leaves a heartbeat file behind: written on connect and refreshed every 30 seconds, but only after `docker.ping()` answers — an open stream is not proof on its own, a half-open socket still looks connected from inside the process. A heartbeat older than 90 seconds, or none at all, now fails with exit code 103. The path is configurable through `TELEGRAM_NOTIFIER_HEARTBEAT_FILE` for setups with a read-only `/tmp`.

## 3. A Telegram outage at start-up disabled the listener

`main()` awaited `sendVersion()` before `sendEventStream()`. If Telegram was unreachable at start-up, `main()` rejected before the listener was ever set up and the container sat there doing nothing — permanently, since nothing retried. It now connects first and treats a failed start-up message as a log line.

## 4. Rate limiting and the error loop

Telegram accepts roughly 20 messages per minute into one group. A crash-looping container produces far more, and every rejected send came back through `sendError` as another message, so the rate limit fed the flood that triggered it.

Sends now run through a queue, one at a time, no closer together than `TELEGRAM_NOTIFIER_SEND_INTERVAL_MS` (default one second). A 429 is retried up to three times honouring `retry_after`. Error notifications are capped at five per five minutes, announced once so the gap is visible. A backlog beyond 200 messages is dropped rather than held — by the time it drained, those notifications would describe something that stopped being true minutes ago.

## 5. Graceful shutdown

`SIGTERM` and `SIGINT` close the stream and exit cleanly, so `docker stop` no longer waits the full ten seconds for the kill.

## Verification

A TCP proxy in front of the docker socket, able to cut connections on demand, standing in for a daemon restart. `telegraf` stubbed to record what would be sent; everything else is the real code against a live daemon.

| scenario | result |
|---|---|
| container before the cut | reported once |
| container **while disconnected** | reported after the reconnect, from `since` |
| container after the reconnect | reported once |
| duplicates across the reconnect | none — 6 events, each exactly once |
| healthcheck, no listener | exit 103, "Not listening for docker events" |
| healthcheck, listener running | exit 0 |
| healthcheck, heartbeat 121s old | exit 103 |
| healthcheck after a reconnect | exit 0 |
| `SIGTERM` | exit 0, heartbeat file removed |
| start-up message fails | logged, listener runs, later events reported |

Plus unit-level checks on the queue: send spacing, `retry_after` honoured, error cap at five, the queue surviving a failed send, and overflow dropping rather than growing.

## Note

The heartbeat interval and the 90 second threshold are not tied to the `HEALTHCHECK` line in the Dockerfile, which has no `--interval` and so uses docker's default of 30 seconds. That works out, but pinning the interval explicitly would make the relationship visible. Left for the Dockerfile pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpQu4cAwjJddpMec8Agd4p