### PR TITLE
Fix the whitelist flag, escape attributes, fail fast on bad config

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 # [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/luc-ass/docker-telegram-notifier/docker-image.yml?branch=main&style=for-the-badge)](https://github.com/luc-ass/docker-telegram-notifier/actions) [![Docker Pulls](https://img.shields.io/docker/pulls/lorcas/docker-telegram-notifier?logo=docker&style=for-the-badge)](https://hub.docker.com/r/lorcas/docker-telegram-notifier) [![Docker Image Version (latest semver)](https://img.shields.io/docker/v/lorcas/docker-telegram-notifier?logo=docker&style=for-the-badge)](https://github.com/luc-ass/docker-telegram-notifier/releases)
 
 
-This Docker container provides a Telegram integration to notify you about Docker events. It can notify you when a container starts, stops (including details about exit codes), restarts, and when the healthcheck status of a Docker container changes. You have the flexibility to customize these notifications by [modifying the `templates.js` file](#3-notification-messages-customization).
+This Docker container provides a Telegram integration to notify you about Docker events. It can notify you when a container starts, stops (including details about exit codes) and when the healthcheck status of a Docker container changes. A restart is reported as a stop followed by a start, since that is what Docker emits. You have the flexibility to customize these notifications by [modifying the `templates.js` file](#3-notification-messages-customization).
 
 This fork was created to address security vulnerabilities and add support for
 - `linux/arm64` and

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ docker run -d --label telegram-notifier.monitor=false hello-world
 
 ### 2.3 Whitelisting
 
-Receive notifications only from whitelisted containers by setting `ONLY_WHITELIST=true` and labeling desired containers:
+Receive notifications only from whitelisted containers by setting `ONLY_WHITELIST=true` and labeling desired containers. The variable is off unless set to a value other than `false`, `0`, `no` or `off`:
 
 ```yaml
 services:

--- a/app.js
+++ b/app.js
@@ -299,10 +299,23 @@ async function healthcheck() {
   process.exit(0);
 }
 
+function checkConfiguration() {
+  const missing = ['TELEGRAM_NOTIFIER_BOT_TOKEN', 'TELEGRAM_NOTIFIER_CHAT_ID']
+    .filter(name => !process.env[name] || process.env[name].trim() === '');
+
+  if (missing.length > 0) {
+    console.error(`Missing required configuration: ${missing.join(', ')}`);
+    console.error('See https://github.com/luc-ass/docker-telegram-notifier#1-basic-setup');
+    process.exit(100);
+  }
+}
+
 function handleError(e) {
   console.error(e);
   telegram.sendError(e).catch(console.error);
 }
+
+checkConfiguration();
 
 if (process.argv.includes("healthcheck")) {
   healthcheck();

--- a/app.js
+++ b/app.js
@@ -5,10 +5,28 @@ const Docker = require('dockerode');
 const TelegramClient = require('./telegram');
 const JSONStream = require('JSONStream');
 const templates = require('./templates');
+const { escapeHtml } = require('./escape');
 
 const { ONLY_WHITELIST } = process.env;
 const docker = new Docker();
 const telegram = new TelegramClient();
+
+/**
+ * Attributes carry arbitrary user input: container names, image tags and any
+ * custom label the README encourages people to add. Escaping them here covers
+ * every template, including the ones people mount themselves, instead of
+ * asking each template to remember.
+ */
+function withEscapedAttributes(event) {
+  const attributes = event.Actor?.Attributes;
+  if (!attributes) return event;
+
+  const escaped = {};
+  for (const [key, value] of Object.entries(attributes)) {
+    escaped[key] = escapeHtml(value);
+  }
+  return { ...event, Actor: { ...event.Actor, Attributes: escaped } };
+}
 
 // The healthcheck runs as its own process and cannot see the state of the
 // event loop, so the listener leaves a heartbeat file behind instead. It is
@@ -71,7 +89,7 @@ async function sendEvent(event) {
         overrides.threadId = isDisabled ? '' : value;
       }
 
-      const attachment = template(event);
+      const attachment = template(withEscapedAttributes(event));
       console.log(attachment, "\n");
       await telegram.send(attachment, overrides);
     }

--- a/app.js
+++ b/app.js
@@ -7,7 +7,19 @@ const JSONStream = require('JSONStream');
 const templates = require('./templates');
 const { escapeHtml } = require('./escape');
 
-const { ONLY_WHITELIST } = process.env;
+/**
+ * Environment values are strings, so the plain truthiness check this used to
+ * do turned ONLY_WHITELIST=false into "whitelist on" — the exact opposite of
+ * what the compose file said.
+ */
+function envFlag(value) {
+  if (value === undefined) return false;
+  const flag = String(value).trim().toLowerCase();
+  return flag !== '' && flag !== 'false' && flag !== '0' &&
+         flag !== 'no' && flag !== 'off';
+}
+
+const ONLY_WHITELIST = envFlag(process.env.ONLY_WHITELIST);
 const docker = new Docker();
 const telegram = new TelegramClient();
 

--- a/app.js
+++ b/app.js
@@ -24,6 +24,35 @@ const docker = new Docker();
 const telegram = new TelegramClient();
 
 /**
+ * Ask docker only for the events we have a template for. Derived from the
+ * template keys rather than hard-coded, so a mounted templates.js that adds
+ * events keeps receiving them.
+ */
+function eventFilters() {
+  const types = new Set();
+  const events = new Set();
+
+  for (const key of Object.keys(templates)) {
+    // Not an event template — sendVersion calls it directly.
+    if (key === 'connection_message') continue;
+
+    const separator = key.indexOf('_');
+    if (separator === -1) continue;
+
+    types.add(key.slice(0, separator));
+    // 'health_status: healthy' is filtered on the action name alone.
+    events.add(key.slice(separator + 1).split(':')[0].trim());
+  }
+
+  // Filtering on nothing would mean receiving nothing, so an unusable set of
+  // templates falls back to the unfiltered stream.
+  if (types.size === 0 || events.size === 0) return null;
+  return { type: [...types], event: [...events] };
+}
+
+const EVENT_FILTERS = eventFilters();
+
+/**
  * Attributes carry arbitrary user input: container names, image tags and any
  * custom label the README encourages people to add. Escaping them here covers
  * every template, including the ones people mount themselves, instead of
@@ -182,6 +211,9 @@ function scheduleReconnect(reason) {
 
 async function connectEventStream() {
   const options = {};
+  if (EVENT_FILTERS) {
+    options.filters = EVENT_FILTERS;
+  }
   if (lastEventTime !== null) {
     options.since = lastEventTime;
   }

--- a/escape.js
+++ b/escape.js
@@ -1,0 +1,14 @@
+/**
+ * Messages are sent with parse_mode HTML, so every value interpolated into
+ * message text has to be escaped. Container names, image tags and custom
+ * labels are arbitrary strings: a single stray '<' makes Telegram reject the
+ * whole message.
+ */
+function escapeHtml(text) {
+  return String(text)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+module.exports = { escapeHtml };

--- a/telegram.js
+++ b/telegram.js
@@ -1,17 +1,5 @@
 const { Telegram } = require('telegraf');
-
-/**
- * Messages are sent with parse_mode HTML, so every value interpolated into
- * message text has to be escaped. Container names, image tags and custom
- * labels are arbitrary strings: a single stray '<' makes Telegram reject the
- * whole message.
- */
-function escapeHtml(text) {
-  return String(text)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-}
+const { escapeHtml } = require('./escape');
 
 /**
  * Telegram expects message_thread_id to be a positive integer. parseInt on a


### PR DESCRIPTION
Phase 4: bugs that quietly do the opposite of what was asked, and the escaping the templates never had.

## 1. `ONLY_WHITELIST=false` switched the whitelist on

Environment values are always strings, and the check was a plain truthiness test. `false` is a non-empty string, so writing `ONLY_WHITELIST: false` in a compose file **enabled** whitelist mode. The symptom is notifications quietly stopping for every container without a label — while the configuration says the feature is off.

`false`, `0`, `no`, `off` and an empty value now all mean off. `ONLY_WHITELIST=true` is unaffected.

> **Behaviour change:** anyone who had `ONLY_WHITELIST=false` set was running in whitelist mode without meaning to. After this they will receive notifications for unlabelled containers again — which is what they asked for in the first place, but it is a change in what they see.

## 2. Attributes went into HTML unescaped

Messages are sent with `parse_mode: HTML` while container names, image tags and custom labels were interpolated raw. Section 3.2.3 of the README explicitly encourages arbitrary text in labels, and one `<` from a label is enough for Telegram to reject the message — the notification is then simply lost.

The escaping happens once, on the attributes, before the template sees them. Doing it inside `templates.js` would have covered the shipped templates only; the README tells people to mount their own, and each of those would have had to remember. This way they are safe without changing anything.

## 3. Missing configuration produced an unrelated error

No bot token meant an opaque 401 from telegraf; no chat id failed later still, inside `sendMessage`. Both are now checked before anything else runs, naming what is missing, with exit code 100. The healthcheck takes the same path.

## 4. The stream carried events nobody wanted

Every event the daemon produces was parsed and looked up only to be discarded — image pulls, network connects, volume mounts. The subscription is now filtered.

The filter is **derived from the template keys**, not hard-coded. A hard-coded filter would make a mounted `templates.js` with a template for a new event silently never fire, which is a miserable thing to debug. An unusable set of templates falls back to the unfiltered stream for the same reason.

## 5. The README promised restart notifications

There is no `container_restart` template and never was. Adding one would not help: `docker restart` emits `kill, kill, stop, die, start, restart`, so the existing templates already report the stop and the start. A third message for the same event, arriving after both, would be noise. The README now says what actually happens.

## Verification

Against a live daemon, `telegraf` stubbed to record sends:

| check | result |
|---|---|
| missing bot token | exit 100, names the variable |
| missing chat id, healthcheck path | exit 100, names the variable |
| `ONLY_WHITELIST=false`, unlabelled container | reported (previously silent) |
| `ONLY_WHITELIST=true`, unlabelled container | not reported |
| `ONLY_WHITELIST=true`, labelled container | reported |
| label `<b>bold</b> & <script>alert(1)</script>` | arrives escaped, no raw tags |
| derived filter | `{type: [container], event: [start, die, health_status]}` |
| `health_status: healthy` through that filter | still delivered |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpQu4cAwjJddpMec8Agd4p