### PR TITLE
Harden the image build, the workflows and add tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@ docker-compose.yml
 Dockerfile*
 README*
 renovate.json
+/test

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,9 @@
+/.git
 /.github
 /.vscode
 /node_modules
 .gitignore
+.DS_Store
 docker-compose.yml
 Dockerfile*
 README*

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,10 +20,18 @@ on:
   schedule:
     - cron: '21 14 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      # Required to upload the analysis results.
+      security-events: write
+      contents: read
+      actions: read
 
     strategy:
       fail-fast: false
@@ -35,11 +43,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7.0.1
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -50,7 +58,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
+      uses: github/codeql-action/autobuild@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -64,4 +72,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,6 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v5
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,58 +2,83 @@ name: docker-build
 
 on:
   release:
-    types: [published] 
-    tags:
-      - 'v*'
-  #push:
-  #  branches:
-  #    - telegraf-v4
+    types: [published]
 
+  # Rebuilds the newest release so base image security patches reach the
+  # published tags without having to cut a release for them.
   schedule:
-      - cron: "0 17 * * 4"
+    - cron: "0 17 * * 4"
 
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Tag to build. Defaults to the newest release."
+        required: false
+
+permissions:
+  contents: read
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - 
+      -
+        name: Work out which version to build
+        id: target
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            version="${{ inputs.version }}"
+          elif [ "${{ github.event_name }}" = "release" ]; then
+            version="${{ github.event.release.tag_name }}"
+          else
+            version="$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName)"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Building $version"
+      -
         name: Checkout
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ steps.target.outputs.version }}
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
-          images:
-            lorcas/docker-telegram-notifier
-          # Modified tags configuration to handle beta versions
+          images: lorcas/docker-telegram-notifier
+          # latest follows the newest stable release, including the scheduled
+          # rebuilds of it. Betas get their own tag and nothing else.
+          flavor: |
+            latest=${{ !contains(steps.target.outputs.version, '-beta') }}
           tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}},enable=${{ !contains(github.ref, '-beta') }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(github.ref, '-beta') }}
-            type=semver,pattern={{major}},enable=${{ !contains(github.ref, '-beta') }}
-            # Add specific handling for beta versions
-            type=match,pattern=v\d+\.\d+\.\d+-beta\.\d+,group=0
+            type=semver,pattern={{version}},value=${{ steps.target.outputs.version }},enable=${{ !contains(steps.target.outputs.version, '-beta') }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.target.outputs.version }},enable=${{ !contains(steps.target.outputs.version, '-beta') }}
+            type=semver,pattern={{major}},value=${{ steps.target.outputs.version }},enable=${{ !contains(steps.target.outputs.version, '-beta') }}
+            type=match,pattern=v\d+\.\d+\.\d+-beta\.\d+,group=0,value=${{ steps.target.outputs.version }}
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-      - 
+        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
+      -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-      - 
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      -
         name: Login to DockerHub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      - 
+          # DOCKERHUB_TOKEN is a scoped Docker Hub access token and is what
+          # this should use. DOCKERHUB_PASSWORD is the account password and
+          # only remains as a fallback until the token secret exists — create
+          # the token, add it, then delete the password secret.
+          password: ${{ secrets.DOCKERHUB_TOKEN || secrets.DOCKERHUB_PASSWORD }}
+      -
         name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -9,7 +9,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-    - uses: actions/first-interaction@v3
+    - uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d # v3.1.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         issue-message: "Hey there! 👋 Thank you for reaching out."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          # Matches the base image the container is built on.
+          node-version: '22'
+          cache: npm
+      - name: Install
+        run: npm ci
+      - name: Test
+        run: npm test

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,14 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 COPY package.json package-lock.json /usr/src/app/
-RUN npm install && npm cache clean --force
+# ci installs exactly what the lockfile says and fails if the two disagree;
+# install may rewrite it, which makes the build unreproducible.
+RUN npm ci --omit=dev && npm cache clean --force
 COPY . /usr/src/app
 
-HEALTHCHECK CMD ["npm", "run", "healthcheck"]
+# The interval is spelled out because the healthcheck depends on it: it fails
+# when the listener's heartbeat is older than 90 seconds, which only leaves
+# room for a missed refresh if it is asked every 30.
+HEALTHCHECK --interval=30s --timeout=10s --start-period=20s --retries=3 \
+  CMD ["npm", "run", "healthcheck"]
 CMD ["npm", "run", "start"]

--- a/app.js
+++ b/app.js
@@ -347,10 +347,27 @@ function handleError(e) {
   telegram.sendError(e).catch(console.error);
 }
 
-checkConfiguration();
+// Only take over the process when run directly, so the tests can import the
+// pure helpers below without starting a listener.
+if (require.main === module) {
+  checkConfiguration();
 
-if (process.argv.includes("healthcheck")) {
-  healthcheck();
-} else {
-  main().catch(handleError);
+  if (process.argv.includes("healthcheck")) {
+    healthcheck();
+  } else {
+    main().catch(handleError);
+  }
 }
+
+module.exports = {
+  envFlag,
+  eventFilters,
+  withEscapedAttributes,
+  isNewEvent,
+  // isNewEvent deliberately keeps its state across calls; the tests need a
+  // way back to a clean slate.
+  resetEventTracking() {
+    lastEventTime = null;
+    handledInLastSecond = new Set();
+  }
+};

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "node app.js",
     "healthcheck": "node app.js healthcheck",
-    "test": "node --test test/"
+    "test": "node --test"
   },
   "author": "poma, arefaslani",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "main": "app.js",
   "scripts": {
     "start": "node app.js",
-    "healthcheck": "node app.js healthcheck"
+    "healthcheck": "node app.js healthcheck",
+    "test": "node --test test/"
   },
   "author": "poma, arefaslani",
   "license": "Apache-2.0",

--- a/test/escape.test.js
+++ b/test/escape.test.js
@@ -1,0 +1,22 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { escapeHtml } = require('../escape');
+
+test('escapes the characters Telegram parses as markup', () => {
+  assert.strictEqual(escapeHtml('<b>x</b>'), '&lt;b&gt;x&lt;/b&gt;');
+  assert.strictEqual(escapeHtml('a & b'), 'a &amp; b');
+});
+
+test('escapes the ampersand first, so entities are not double-escaped wrongly', () => {
+  assert.strictEqual(escapeHtml('&lt;'), '&amp;lt;');
+});
+
+test('leaves ordinary text alone', () => {
+  assert.strictEqual(escapeHtml('nginx:1.27-alpine'), 'nginx:1.27-alpine');
+  assert.strictEqual(escapeHtml('web_server-1'), 'web_server-1');
+});
+
+test('accepts values that are not strings', () => {
+  assert.strictEqual(escapeHtml(137), '137');
+  assert.strictEqual(escapeHtml(undefined), 'undefined');
+});

--- a/test/events.test.js
+++ b/test/events.test.js
@@ -1,0 +1,92 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+process.env.TELEGRAM_NOTIFIER_BOT_TOKEN = '000:test';
+process.env.TELEGRAM_NOTIFIER_CHAT_ID = '-100test';
+const app = require('../app');
+
+test('envFlag treats the string "false" as off', () => {
+  // The bug this replaced: any non-empty string counted as on, so
+  // ONLY_WHITELIST=false switched whitelist mode on.
+  assert.strictEqual(app.envFlag('false'), false);
+  assert.strictEqual(app.envFlag('FALSE'), false);
+  assert.strictEqual(app.envFlag(' false '), false);
+  assert.strictEqual(app.envFlag('0'), false);
+  assert.strictEqual(app.envFlag('no'), false);
+  assert.strictEqual(app.envFlag('off'), false);
+  assert.strictEqual(app.envFlag(''), false);
+  assert.strictEqual(app.envFlag(undefined), false);
+});
+
+test('envFlag treats anything else as on', () => {
+  assert.strictEqual(app.envFlag('true'), true);
+  assert.strictEqual(app.envFlag('1'), true);
+  assert.strictEqual(app.envFlag('yes'), true);
+});
+
+test('the event filter is derived from the template names', () => {
+  const filters = app.eventFilters();
+  assert.deepStrictEqual(filters.type, ['container']);
+  assert.deepStrictEqual(filters.event.sort(), ['die', 'health_status', 'start']);
+});
+
+test('the event filter leaves out connection_message', () => {
+  assert.ok(!app.eventFilters().type.includes('connection'));
+});
+
+test('attributes are escaped before a template sees them', () => {
+  const event = {
+    Type: 'container',
+    Action: 'start',
+    Actor: { ID: 'abc', Attributes: { name: '<b>x</b>', info: 'a & b' } }
+  };
+  const escaped = app.withEscapedAttributes(event);
+
+  assert.strictEqual(escaped.Actor.Attributes.name, '&lt;b&gt;x&lt;/b&gt;');
+  assert.strictEqual(escaped.Actor.Attributes.info, 'a &amp; b');
+  // The original must not be touched; the label checks read it unescaped.
+  assert.strictEqual(event.Actor.Attributes.name, '<b>x</b>');
+  assert.strictEqual(escaped.Actor.ID, 'abc');
+});
+
+test('an event without an actor passes through untouched', () => {
+  const event = { Type: 'container', Action: 'start' };
+  assert.strictEqual(app.withEscapedAttributes(event), event);
+});
+
+test('a replayed event is recognised after a reconnect', () => {
+  app.resetEventTracking();
+  const first = { time: 100, timeNano: 100_000_000_100, Type: 'container', Action: 'start', Actor: { ID: 'a' } };
+  const second = { time: 100, timeNano: 100_000_000_200, Type: 'container', Action: 'die', Actor: { ID: 'a' } };
+
+  assert.strictEqual(app.isNewEvent(first), true);
+  assert.strictEqual(app.isNewEvent(second), true);
+  // `since` is inclusive, so a reconnect delivers both of them again.
+  assert.strictEqual(app.isNewEvent(first), false);
+  assert.strictEqual(app.isNewEvent(second), false);
+});
+
+test('a later event is still accepted after a replay', () => {
+  app.resetEventTracking();
+  app.isNewEvent({ time: 100, timeNano: 1, Type: 'container', Action: 'start', Actor: { ID: 'a' } });
+  assert.strictEqual(
+    app.isNewEvent({ time: 101, timeNano: 2, Type: 'container', Action: 'start', Actor: { ID: 'b' } }),
+    true
+  );
+});
+
+test('two different containers in the same second are both new', () => {
+  app.resetEventTracking();
+  const at = 500;
+  assert.strictEqual(app.isNewEvent({ time: at, timeNano: 1, Type: 'container', Action: 'start', Actor: { ID: 'a' } }), true);
+  assert.strictEqual(app.isNewEvent({ time: at, timeNano: 2, Type: 'container', Action: 'start', Actor: { ID: 'b' } }), true);
+});
+
+test('an event older than the marker is dropped', () => {
+  app.resetEventTracking();
+  app.isNewEvent({ time: 200, timeNano: 1, Type: 'container', Action: 'start', Actor: { ID: 'a' } });
+  assert.strictEqual(
+    app.isNewEvent({ time: 199, timeNano: 0, Type: 'container', Action: 'start', Actor: { ID: 'a' } }),
+    false
+  );
+});

--- a/test/telegram.test.js
+++ b/test/telegram.test.js
@@ -1,0 +1,123 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+process.env.TELEGRAM_NOTIFIER_BOT_TOKEN = '000:test';
+process.env.TELEGRAM_NOTIFIER_CHAT_ID = '-100test';
+process.env.TELEGRAM_NOTIFIER_SEND_INTERVAL_MS = '0';
+const TelegramClient = require('../telegram');
+
+// Records what would have gone to Telegram instead of sending it.
+function recording() {
+  const client = new TelegramClient();
+  const sent = [];
+  client.telegram.sendMessage = async (chatId, text, options) => {
+    sent.push({ chatId, text, options });
+    return {};
+  };
+  return { client, sent };
+}
+
+test('a numeric thread id is passed through', async () => {
+  const { client, sent } = recording();
+  await client.send('x', { threadId: '42' });
+  assert.strictEqual(sent[0].options.message_thread_id, 42);
+});
+
+test('surrounding whitespace in a thread id is tolerated', async () => {
+  const { client, sent } = recording();
+  await client.send('x', { threadId: '  42  ' });
+  assert.strictEqual(sent[0].options.message_thread_id, 42);
+});
+
+test('an unusable thread id is dropped, not sent as NaN', async () => {
+  const { client, sent } = recording();
+  const errors = [];
+  const original = console.error;
+  console.error = (m) => errors.push(String(m));
+  await client.send('x', { threadId: 'general' });
+  console.error = original;
+
+  assert.ok(!('message_thread_id' in sent[0].options));
+  assert.strictEqual(sent[0].text, 'x', 'the message itself must still go out');
+  assert.match(errors[0], /general/);
+});
+
+test('an explicitly empty thread id turns the global topic off', async () => {
+  process.env.TELEGRAM_NOTIFIER_TOPIC_ID = '99';
+  const { client, sent } = recording();
+  await client.send('x', { threadId: '' });
+  delete process.env.TELEGRAM_NOTIFIER_TOPIC_ID;
+  assert.ok(!('message_thread_id' in sent[0].options));
+});
+
+test('is_topic_message is never sent — it is a response field', async () => {
+  const { client, sent } = recording();
+  await client.send('x', { threadId: '42' });
+  assert.ok(!('is_topic_message' in sent[0].options));
+});
+
+test('the failed payload is escaped before it goes into the error message', async () => {
+  const { client, sent } = recording();
+  await client.sendError({
+    response: { error_code: 400, description: 'Bad Request: message thread not found' },
+    on: { method: 'sendMessage', payload: { text: '<b>web</b> started & running' } }
+  });
+
+  const body = sent[0].text;
+  const payload = body.slice(body.indexOf('<pre>') + 5, body.indexOf('</pre>'));
+  assert.ok(!payload.includes('<b>'), 'raw markup would break the error report');
+  assert.match(payload, /&lt;b&gt;web&lt;\/b&gt;/);
+  assert.match(payload, /&amp;/);
+});
+
+test('an error that did not come from Telegram is not labelled sendMessage', async () => {
+  const { client, sent } = recording();
+  await client.sendError(new Error('docker socket closed'));
+
+  assert.match(sent[0].text, /\[Error\] 0 - docker socket closed/);
+  assert.ok(!sent[0].text.includes('<pre>'), 'there is no payload to show');
+  assert.ok(!sent[0].text.includes('undefined'));
+});
+
+test('error notifications stop after five in a window', async () => {
+  const { client, sent } = recording();
+  const original = console.error;
+  console.error = () => {};
+  for (let i = 0; i < 12; i++) await client.sendError(new Error('boom'));
+  console.error = original;
+  assert.strictEqual(sent.length, 5);
+});
+
+test('a rate limit is retried, honouring retry_after', async () => {
+  const client = new TelegramClient();
+  let calls = 0;
+  client.telegram.sendMessage = async () => {
+    if (++calls === 1) {
+      const e = new Error('Too Many Requests');
+      e.response = { parameters: { retry_after: 0 } };
+      throw e;
+    }
+    return { ok: true };
+  };
+
+  const original = console.error;
+  console.error = () => {};
+  const result = await client.send('x');
+  console.error = original;
+
+  assert.strictEqual(calls, 2);
+  assert.deepStrictEqual(result, { ok: true });
+});
+
+test('a failed send does not stop the ones behind it', async () => {
+  const client = new TelegramClient();
+  let calls = 0;
+  client.telegram.sendMessage = async () => {
+    if (++calls === 1) throw new Error('nope');
+    return { ok: true };
+  };
+
+  await assert.rejects(() => client.send('first'));
+  await client.send('second');
+  assert.strictEqual(calls, 2);
+});

--- a/test/templates.test.js
+++ b/test/templates.test.js
@@ -1,0 +1,49 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const templates = require('../templates');
+
+const event = (attributes) => ({ Actor: { Attributes: { name: 'web', image: 'nginx', ...attributes } } });
+
+test('a start message names the container and the image', () => {
+  const message = templates.container_start(event());
+  assert.match(message, /<b>web<\/b> started/);
+  assert.match(message, /<code>nginx<\/code>/);
+});
+
+test('exit code 0 is reported as a clean shutdown', () => {
+  const message = templates.container_die(event({ exitCode: '0' }));
+  assert.match(message, /Successful shutdown/);
+  // The stop symbol, not the red circle reserved for failures.
+  assert.match(message, /&#9209;/);
+});
+
+test('SIGTERM counts as a normal shutdown', () => {
+  assert.match(templates.container_die(event({ exitCode: '143' })), /Graceful termination/);
+});
+
+test('a failure exit code is explained and marked', () => {
+  const message = templates.container_die(event({ exitCode: '137' }));
+  assert.match(message, /SIGKILL/);
+  assert.match(message, /&#128308;/);
+});
+
+test('an unknown exit code still reports the number', () => {
+  const message = templates.container_die(event({ exitCode: '42' }));
+  assert.match(message, /Exit code: 42/);
+  assert.match(message, /&#128308;/);
+});
+
+test('health status has a template for both directions', () => {
+  assert.match(templates['container_health_status: healthy'](event()), /healthy/);
+  assert.match(templates['container_health_status: unhealthy'](event()), /unhealthy!/);
+});
+
+test('the connection message carries the host details', () => {
+  const message = templates.connection_message({
+    hostname: 'srv1', version: '29.7.2', os: 'Debian', type: 'linux',
+    architecture: 'x86_64', cpu: 8, memory: '7934 MB'
+  });
+  assert.match(message, /<b>srv1<\/b>/);
+  assert.match(message, /docker v29\.7\.2/);
+  assert.match(message, /8 Cores/);
+});


### PR DESCRIPTION
Phase 5: the build and delivery chain around the code, plus the test suite it never had.

## 1. `.git` was being shipped inside the image

`.dockerignore` listed `.github` but not `.git`, so `COPY . /usr/src/app` pulled the entire repository history into the published image — every commit, every branch, shipped to everyone who pulls it. `.DS_Store` and `/test` are excluded too.

## 2. `npm install` → `npm ci`

`npm install` is free to rewrite `package-lock.json`, so a build could quietly resolve different versions than the ones that were reviewed and scanned. `npm ci` installs exactly what the lockfile says and fails if the two disagree.

The `HEALTHCHECK` interval is now explicit. The healthcheck fails when the listener's heartbeat is older than 90 seconds, which only leaves room for one missed refresh if it is asked every 30 — that relationship was invisible while it relied on docker's default.

## 3. The scheduled rebuild never touched `latest`

This is the one worth reading twice. The weekly rebuild exists so base image security patches reach the published image without cutting a release. **It never did that.** On a scheduled run only `type=ref,event=branch` applied, so the run produced a tag called `main` — `latest`, `1`, `1.4` and the version tags were untouched. Anyone on `latest` stayed on the image from the last release.

Scheduled and manual runs now resolve the newest release, check that tag out and publish it under the full set of semver tags including `latest`. `workflow_dispatch` takes an optional version so an older release can be rebuilt deliberately.

The invalid `tags:` filter under the `release` trigger is gone; it only ever applied to `push` events.

## 4. Actions pinned to SHAs, permissions restricted

A version tag is mutable: whoever controls the action repository can move it and every run silently picks up new code. The version stays in a trailing comment, which is also the form Dependabot updates.

CodeQL had no `permissions` block and ran with the repository default. It now gets `contents: read`, `actions: read` and the `security-events: write` it needs, and nothing more. The build workflow gets `contents: read`.

## 5. Docker Hub credentials

`secrets.DOCKERHUB_PASSWORD` is the account password, created in 2022. The login now prefers `secrets.DOCKERHUB_TOKEN` and falls back to the old secret, so nothing breaks before the token exists.

> **Action needed after merging:** create a scoped access token on Docker Hub, add it as `DOCKERHUB_TOKEN`, then delete `DOCKERHUB_PASSWORD`. Until then the fallback keeps the account password in use.

## 6. A test suite, and CI that runs it

There were no tests, which is uncomfortable for code whose failure mode is silence rather than a crash. 31 tests over exactly what broke before:

- `envFlag` treating `"false"` as off
- the event filter derived from the template names, and `connection_message` excluded from it
- attributes escaped without touching the original that the label checks read
- replayed events recognised after a reconnect, and later ones still accepted
- non-numeric thread ids dropped rather than sent as `NaN`, with the message still delivered
- `is_topic_message` never sent
- the error payload escaped, non-Telegram errors not labelled `sendMessage`
- the error cap, `retry_after` honoured, and a failed send not blocking the queue behind it
- the exit code mapping in the templates

`app.js` only takes over the process when run directly, so the helpers can be imported without starting a listener. `node:test` is built in, so `devDependencies` stays empty.

## Two things I did not do, deliberately

**No `USER node`.** The documented setup bind-mounts `/var/run/docker.sock`, which on Linux is `srw-rw---- root:docker`. A non-root user without that group cannot read it, so this would break every existing deployment unless each one added `group_add`. It belongs with the socket proxy work in phase 6, where the notifier talks HTTP and needs no socket permissions at all.

**No digest pin on the base image.** Pinning `node:22-slim` by digest would make the weekly rebuild rebuild the same base image forever, which defeats the point of having it — base image patches would then depend on merging a Dependabot PR in a repository that just went ten months without one. The floating tag plus the lockfile is the better trade here.

Both were on my own list from the initial review. Looking at them against how this project actually ships, both were wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpQu4cAwjJddpMec8Agd4p