### PR TITLE
Prepare 1.5.0

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -68,11 +68,7 @@ jobs:
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          # DOCKERHUB_TOKEN is a scoped Docker Hub access token and is what
-          # this should use. DOCKERHUB_PASSWORD is the account password and
-          # only remains as a fallback until the token secret exists — create
-          # the token, add it, then delete the password secret.
-          password: ${{ secrets.DOCKERHUB_TOKEN || secrets.DOCKERHUB_PASSWORD }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docker-telegram-notifier",
-  "version": "1.4.11",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docker-telegram-notifier",
-      "version": "1.4.11",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "dockerode": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-telegram-notifier",
-  "version": "1.4.11",
+  "version": "1.5.0",
   "description": "Docker container to inform you about docker-events via telegram",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Two small things ahead of the release.

**Docker Hub login.** `DOCKERHUB_PASSWORD` has been replaced with a scoped access token, so the fallback expression that kept the account password usable is dead code and comes out.

**Version 1.5.0, not 1.4.12.** Since v1.4.11 this has gained reconnect handling for the event stream, a healthcheck that can actually fail, send rate limiting, HTML escaping of container attributes and configuration validation — and it changes what `ONLY_WHITELIST=false` does. That is more than a patch release should carry.

> Note: PR #116 (proxy support) is currently assigned to the v1.5.0 milestone and is not part of this. It needs a decision either way — that is a phase 6 item — so the milestone wants moving or closing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpQu4cAwjJddpMec8Agd4p