### PR TITLE
Document the docker socket, support secrets as files

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,14 @@ If you encounter any issues, please feel free to contribute by fixing them and o
   - [2.3 Whitelisting](#23-whitelisting)
   - [2.4 Per container notifications](#24-per-container-notifications)
   - [2.5 Remote docker instance](#25-remote-docker-instance)
+  - [2.6 Bot token from a file](#26-bot-token-from-a-file)
 - [3. Notification messages customization](#3-notification-messages-customization)
   - [3.1 Create a custom template](#31-create-a-custom-template)
   - [3.2 Customizing message strings](#32-customizing-message-strings)
   - [3.2.1 Default docker event variables](#321-default-docker-event-variables)
   - [3.2.2 Docker Compose variables](#322-docker-compose-variables)
   - [3.2.3 Custom container information in Telegram notifications](#323-custom-container-information-in-telegram-notifications)
+- [4. Securing the docker socket](#4-securing-the-docker-socket)
 - [Credits](#credits)
 
 
@@ -202,6 +204,30 @@ services:
 ```
 
 
+### 2.6 Bot token from a file
+
+Environment variables are readable by anyone who can run `docker inspect` on the container. To keep the bot token out of them, append `_FILE` to the variable name and point it at a file:
+
+```yaml
+services:
+  telegram-notifier:
+    image: lorcas/docker-telegram-notifier:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      TELEGRAM_NOTIFIER_BOT_TOKEN_FILE: /run/secrets/telegram_bot_token
+      TELEGRAM_NOTIFIER_CHAT_ID: <chat_id>
+    secrets:
+      - telegram_bot_token
+
+secrets:
+  telegram_bot_token:
+    file: ./telegram_bot_token.txt
+```
+
+`TELEGRAM_NOTIFIER_CHAT_ID_FILE` works the same way. A trailing newline in the file is ignored. If the file cannot be read, the container stops immediately with exit code 100 and names the file it tried to open.
+
+
 ## 3. Notification messages customization
 
 ### 3.1 Create a custom template
@@ -245,10 +271,15 @@ Here are some variables available to customize the notification messages.
 
 | Variable | Description |
 | :-------- | :----------- |
+| `${e.Actor.ID}` | Container ID (full, 64 characters) |
 | `${e.Actor.Attributes.name}` | Container name |
-| `${e.Actor.Attributes.container}` | Container ID |
 | `${e.Actor.Attributes.image}` | Container image used |
-| `${e.Actor.Attirbutes.exitCode}` | Container exit code |
+| `${e.Actor.Attributes.exitCode}` | Container exit code (`die` events only) |
+| `${e.Actor.Attributes.execDuration}` | Seconds the container ran (`die` events only) |
+
+Beyond those, **every label on the container is available under the same path**, which is what makes [custom container information](#323-custom-container-information-in-telegram-notifications) work. That includes the labels `docker compose` adds by itself, listed below.
+
+`Attributes` is a plain object, so values are `undefined` when the event does not carry them — `exitCode` on a `start` event, for instance. The authoritative list of what an event can contain is the [Docker Engine API](https://docs.docker.com/reference/api/engine/version/v1.51/#tag/System/operation/SystemEvents); the notifier passes it through unchanged, apart from HTML-escaping the values.
 
 Example:
 ```js
@@ -256,7 +287,7 @@ container_start: e =>
     `&#9989; Container Started\n` +
     `Name: <b>${e.Actor.Attributes.name}</b>\n` +
     `Image: <code>${e.Actor.Attributes.image}</code>\n` +
-    `ID: <code>${e.Actor.Attributes.container}</code>`
+    `ID: <code>${e.Actor.ID.slice(0, 12)}</code>`
 ```
 ```
 🟢 Container Started
@@ -276,6 +307,8 @@ The following variables are only available if the container was started using `d
 | `${e.Actor.Attributes['com.docker.compose.service']}` | Compose Service Name |
 | `${e.Actor.Attributes['com.docker.compose.version']}` | Compose Version |
 
+Compose adds more than these — `com.docker.compose.config-hash`, `com.docker.compose.image`, `com.docker.compose.oneoff`, `com.docker.compose.project.config_files` and `com.docker.compose.project.working_dir` are present as well. They are ordinary labels, so they are reached the same way.
+
 Example:
 ```js
 container_start: e =>
@@ -283,7 +316,7 @@ container_start: e =>
     `Project: <b>${e.Actor.Attributes['com.docker.compose.project']}</b>\n` +
     `Service: <b>${e.Actor.Attributes['com.docker.compose.service']}</b> (#${e.Actor.Attributes['com.docker.compose.container-number']})\n` +
     `Image: <code>${e.Actor.Attributes.image}</code>\n` +
-    `Compose Version: <code>${e.Actor.Attributes['com.docker.compose.version']}<code>`
+    `Compose Version: <code>${e.Actor.Attributes['com.docker.compose.version']}</code>`
 ```
 ```
 🟢 Container Started
@@ -324,13 +357,57 @@ Leverage the `labels:` defintion on docker services to make custom information a
     ```js
     container_start: e =>
         `&#9654;&#65039; <b>${e.Actor.Attributes.name}</b> started\n` +
-        `Image: <code>${e.Actor.Attributes.image}</code>\n` +
+        `Image: <code>${e.Actor.Attributes.image}</code>` +
         (
-          ${e.Actor.Attributes['mycustom.telegram.container-info']} ?
-          `NOTE: ${e.Actor.Attributes['mycustom.telegram.container-info']}` :
+          e.Actor.Attributes['mycustom.telegram.container-info'] ?
+          `\nNOTE: ${e.Actor.Attributes['mycustom.telegram.container-info']}` :
           ''
         )
     ```
+
+## 4. Securing the docker socket
+
+The basic setup mounts the docker socket read-only:
+
+```yaml
+volumes:
+  - /var/run/docker.sock:/var/run/docker.sock:ro
+```
+
+**`:ro` protects the socket file, not the API behind it.** Anything that can reach the docker socket can create a container, mount any host path into it and run it as root — so it can take over the host, read-only mount or not. That applies to every tool that reads docker events this way, this one included.
+
+This notifier only needs four read-only endpoints: `version`, `info`, `ping` and `events`. A socket proxy is a small container that exposes exactly those and refuses everything else:
+
+```yaml
+services:
+  docker-socket-proxy:
+    image: tecnativa/docker-socket-proxy:latest
+    environment:
+      EVENTS: 1   # the event stream itself
+      INFO: 1     # host details in the start-up message
+      PING: 1     # the healthcheck's liveness probe
+      VERSION: 1  # docker version in the start-up message
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    restart: unless-stopped
+
+  telegram-notifier:
+    image: lorcas/docker-telegram-notifier:latest
+    depends_on:
+      - docker-socket-proxy
+    environment:
+      DOCKER_HOST: tcp://docker-socket-proxy:2375
+      TELEGRAM_NOTIFIER_BOT_TOKEN: <bot_token>
+      TELEGRAM_NOTIFIER_CHAT_ID: <chat_id>
+    restart: unless-stopped
+```
+
+The notifier gets no volume at all in this setup — it talks HTTP to the proxy, and the proxy is the only container holding the socket. Everything the proxy does not explicitly allow is refused, so a compromised notifier cannot create containers.
+
+Keep the proxy off any published port. It has no authentication, so anything that can reach it inherits its permissions.
+
+> This combination is tested: with those four permissions enabled and everything else at its default of off, both notifications and the healthcheck work. `PING` is easy to miss — the healthcheck uses it to tell a live daemon from a stalled event stream.
+
 
 ## Credits
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Policy
+
+## Supported versions
+
+Fixes go into the most recent release only. The published image is rebuilt
+weekly so base image updates reach the `latest`, `1`, `1.x` and version tags
+without waiting for a release.
+
+| Version | Supported |
+| :------ | :-------- |
+| newest release | yes |
+| anything older | no |
+
+## Reporting a vulnerability
+
+Please use [private vulnerability reporting](https://github.com/luc-ass/docker-telegram-notifier/security/advisories/new)
+rather than a public issue, and allow some time for a response — this is a
+small project maintained in spare time.
+
+Include what you need to reproduce it: the version or image tag, the relevant
+part of your compose file with secrets removed, and what you observed.
+
+## What this container can reach
+
+Worth knowing before you deploy it, and relevant to how you judge a finding:
+
+- **The docker socket is full control of the host.** The documented setup
+  mounts `/var/run/docker.sock` read-only, but `:ro` only protects the socket
+  file — the API behind it can still create privileged containers. Section 4
+  of the README describes running the notifier behind a socket proxy that
+  exposes only `version`, `info`, `ping` and `events`, which is the safer
+  arrangement.
+- **The bot token is a credential for your Telegram bot.** Passed as an
+  environment variable it is readable through `docker inspect`. It can be
+  supplied as a file instead — see section 2.6 of the README.
+- **Container names, image tags and labels end up in messages.** They are
+  HTML-escaped before being sent, so a container whose labels contain markup
+  cannot break or forge the notification.
+- **Notifications are sent to whichever chat is configured.** Anyone who can
+  start containers on the monitored host can therefore cause messages in that
+  chat, which is inherent to what the tool does.

--- a/app.js
+++ b/app.js
@@ -6,6 +6,11 @@ const TelegramClient = require('./telegram');
 const JSONStream = require('JSONStream');
 const templates = require('./templates');
 const { escapeHtml } = require('./escape');
+const { loadFileSettings } = require('./secrets');
+
+// Before anything reads them: a token handed over as a file must be in place
+// before the Telegram client is constructed below.
+loadFileSettings(['TELEGRAM_NOTIFIER_BOT_TOKEN', 'TELEGRAM_NOTIFIER_CHAT_ID']);
 
 /**
  * Environment values are strings, so the plain truthiness check this used to

--- a/secrets.js
+++ b/secrets.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+
+/**
+ * Resolves settings that may be delivered as a file instead of an
+ * environment variable: for each name, <NAME>_FILE wins over <NAME> and its
+ * contents replace the variable for the rest of the process.
+ *
+ * This matters for the bot token. An environment variable is visible to
+ * anyone who can run `docker inspect` on the container — which, given this
+ * container is normally given the docker socket, is a wider circle than it
+ * looks. Docker and compose secrets are delivered as files.
+ *
+ * The value is put back into process.env rather than passed around: it is
+ * read at several points, and a runtime assignment is not part of the
+ * container's configuration, so it does not show up in `docker inspect`.
+ */
+function loadFileSettings(names) {
+  for (const name of names) {
+    const file = process.env[`${name}_FILE`];
+    if (!file) continue;
+
+    try {
+      process.env[name] = fs.readFileSync(file, 'utf8').trim();
+    } catch (e) {
+      console.error(`Could not read ${name}_FILE at ${file}: ${e.message}`);
+      process.exit(100);
+    }
+  }
+}
+
+module.exports = { loadFileSettings };

--- a/test/secrets.test.js
+++ b/test/secrets.test.js
@@ -1,0 +1,33 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { loadFileSettings } = require('../secrets');
+
+test('a value handed over as a file replaces the variable', () => {
+  const file = path.join(os.tmpdir(), `dtn-secret-${process.pid}`);
+  fs.writeFileSync(file, '  123:secret-token\n');
+
+  process.env.DTN_TEST_TOKEN = 'from-environment';
+  process.env.DTN_TEST_TOKEN_FILE = file;
+  loadFileSettings(['DTN_TEST_TOKEN']);
+
+  // Trailing newlines are what trips people up when they echo into a file.
+  assert.strictEqual(process.env.DTN_TEST_TOKEN, '123:secret-token');
+  fs.unlinkSync(file);
+  delete process.env.DTN_TEST_TOKEN;
+  delete process.env.DTN_TEST_TOKEN_FILE;
+});
+
+test('without the _FILE variant the environment is left alone', () => {
+  process.env.DTN_TEST_PLAIN = 'unchanged';
+  loadFileSettings(['DTN_TEST_PLAIN']);
+  assert.strictEqual(process.env.DTN_TEST_PLAIN, 'unchanged');
+  delete process.env.DTN_TEST_PLAIN;
+});
+
+test('a name that is set nowhere stays unset', () => {
+  loadFileSettings(['DTN_TEST_ABSENT']);
+  assert.strictEqual(process.env.DTN_TEST_ABSENT, undefined);
+});


### PR DESCRIPTION
First part of phase 6: the security documentation and the doc bugs. The two open feature questions (#91, #116) are separate.

## The docker socket

The README told people to mount the socket with `:ro` without saying what that does and does not protect. It protects the socket *file*; the API behind it can still create privileged containers with any host path mounted, so anything reaching it effectively owns the host. That is true of every tool that reads docker events this way — it just was not written down.

New section 4 says it plainly and gives a socket proxy setup where the notifier holds **no volume at all**, talks HTTP to the proxy, and can reach only `version`, `info`, `ping` and `events`.

**This is tested, not sketched.** I ran the notifier against `tecnativa/docker-socket-proxy` with exactly those four permissions and everything else at its default of off: notifications arrive and the healthcheck passes. `PING` is called out explicitly in the example because it is the easy one to miss — the healthcheck uses it to tell a live daemon from a stalled event stream, which is not obvious from outside.

## Secrets as files

`TELEGRAM_NOTIFIER_BOT_TOKEN_FILE` and `TELEGRAM_NOTIFIER_CHAT_ID_FILE` take a path, which is how docker and compose deliver secrets. A trailing newline is stripped — writing a token into a file with `echo` is the obvious way to do it and the obvious way to get it wrong. An unreadable file stops the container with exit code 100 and names the file.

The value replaces the environment variable for the rest of the process, so the reading points stay unchanged. A runtime assignment is not part of the container's configuration, so the token still does not show up in `docker inspect`.

## Three broken examples

These matter because people copy them into a mounted `templates.js`, where a mistake is silent:

| where | problem |
|---|---|
| 3.2.1 table and example | `Attributes.container` does not exist on container events — the example printed `undefined`. The container id is `Actor.ID`. |
| 3.2.1 table | `Attirbutes` was a typo for `Attributes`. |
| 3.2.2 example | closed a `<code>` tag with `<code>`, which Telegram rejects outright. |
| 3.2.3 example | the `if` condition interpolated the value it was meant to test — reported by @oliveratgithub in #91. |

## The attribute list (#95)

Answered from a real captured event rather than from memory. The variable table now says what is actually there: `Actor.ID`, `name`, `image`, and `exitCode` / `execDuration` on `die` events only — plus the point that makes the whole customization feature work, which was never stated: **every label on the container is reachable the same way**. The compose section gains the labels compose actually sets beyond the four listed.

Closes #95.

## SECURITY.md

Where to report, and what this container can reach — the socket, the bot token, and the fact that anyone who can start containers on the monitored host can cause messages in the configured chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpQu4cAwjJddpMec8Agd4p