### PR TITLE
Support an outbound HTTPS proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ If you encounter any issues, please feel free to contribute by fixing them and o
   - [2.4 Per container notifications](#24-per-container-notifications)
   - [2.5 Remote docker instance](#25-remote-docker-instance)
   - [2.6 Bot token from a file](#26-bot-token-from-a-file)
+  - [2.7 Outbound proxy](#27-outbound-proxy)
 - [3. Notification messages customization](#3-notification-messages-customization)
   - [3.1 Create a custom template](#31-create-a-custom-template)
   - [3.2 Customizing message strings](#32-customizing-message-strings)
@@ -226,6 +227,40 @@ secrets:
 ```
 
 `TELEGRAM_NOTIFIER_CHAT_ID_FILE` works the same way. A trailing newline in the file is ignored. If the file cannot be read, the container stops immediately with exit code 100 and names the file it tried to open.
+
+
+### 2.7 Outbound proxy
+
+If the host reaches the internet through a proxy, set `HTTPS_PROXY` and the notifier will send its Telegram requests through it:
+
+```yaml
+services:
+  telegram-notifier:
+    image: lorcas/docker-telegram-notifier:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      TELEGRAM_NOTIFIER_BOT_TOKEN: <bot_token>
+      TELEGRAM_NOTIFIER_CHAT_ID: <chat_id>
+      HTTPS_PROXY: http://proxy.example.com:8080
+```
+
+<details>
+<summary>
+docker run
+</summary>
+
+```sh
+docker run -d \
+  --env TELEGRAM_NOTIFIER_BOT_TOKEN=<bot_token> \
+  --env TELEGRAM_NOTIFIER_CHAT_ID=<chat_id> \
+  --env HTTPS_PROXY=http://proxy.example.com:8080 \
+  --volume /var/run/docker.sock:/var/run/docker.sock:ro \
+  lorcas/docker-telegram-notifier
+```
+</details>
+
+The lowercase `https_proxy` is accepted as well. This only affects the connection to Telegram; the docker socket is not reached over the network. An unusable proxy URL stops the container with exit code 100.
 
 
 ## 3. Notification messages customization

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "dockerode": "^5.0.1",
+        "https-proxy-agent": "^7.0.6",
         "JSONStream": "^1.3.5",
         "telegraf": "^4.16.3"
       }
@@ -161,6 +162,15 @@
       },
       "engines": {
         "node": ">=6.5"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ansi-regex": {
@@ -438,6 +448,19 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ieee754": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "dockerode": "^5.0.1",
+    "https-proxy-agent": "^7.0.6",
     "JSONStream": "^1.3.5",
     "telegraf": "^4.16.3"
   }

--- a/telegram.js
+++ b/telegram.js
@@ -1,4 +1,5 @@
 const { Telegram } = require('telegraf');
+const { HttpsProxyAgent } = require('https-proxy-agent');
 const { escapeHtml } = require('./escape');
 
 /**
@@ -33,9 +34,29 @@ function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+/**
+ * node-fetch, which telegraf sends through, does not read the proxy
+ * environment variables by itself, so the agent has to be built explicitly.
+ * Only when one is actually configured: HttpsProxyAgent throws on an empty or
+ * missing value, which would take the container down for everyone not behind
+ * a proxy.
+ */
+function proxyOptions() {
+  const proxy = process.env.HTTPS_PROXY || process.env.https_proxy;
+  if (!proxy) return {};
+
+  try {
+    return { agent: new HttpsProxyAgent(proxy) };
+  } catch (e) {
+    console.error(`HTTPS_PROXY is not a usable URL: ${proxy}`);
+    console.error(e.message);
+    process.exit(100);
+  }
+}
+
 class TelegramClient {
   constructor() {
-    this.telegram = new Telegram(process.env.TELEGRAM_NOTIFIER_BOT_TOKEN);
+    this.telegram = new Telegram(process.env.TELEGRAM_NOTIFIER_BOT_TOKEN, proxyOptions());
     this.queue = Promise.resolve();
     this.queued = 0;
     this.lastSentAt = 0;

--- a/test/proxy.test.js
+++ b/test/proxy.test.js
@@ -1,0 +1,47 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+process.env.TELEGRAM_NOTIFIER_BOT_TOKEN = '000:test';
+process.env.TELEGRAM_NOTIFIER_CHAT_ID = '-100test';
+const TelegramClient = require('../telegram');
+const { HttpsProxyAgent } = require('https-proxy-agent');
+
+// telegraf always supplies an agent of its own (a keep-alive https.Agent), so
+// "no proxy" means that default is left in place rather than no agent at all.
+const usesProxy = (client) => client.telegram.options.agent instanceof HttpsProxyAgent;
+
+test('no proxy configured means no agent, and no crash', () => {
+  // The whole point: HttpsProxyAgent throws on an empty value, so building it
+  // unconditionally would take the container down for everyone.
+  delete process.env.HTTPS_PROXY;
+  delete process.env.https_proxy;
+
+  const client = new TelegramClient();
+  assert.strictEqual(usesProxy(client), false);
+  assert.ok(client.telegram.options.agent, "telegraf's own default agent stays");
+});
+
+test('an empty HTTPS_PROXY is treated as unset', () => {
+  process.env.HTTPS_PROXY = '';
+  const client = new TelegramClient();
+  assert.strictEqual(usesProxy(client), false);
+  delete process.env.HTTPS_PROXY;
+});
+
+test('a configured proxy becomes an agent', () => {
+  process.env.HTTPS_PROXY = 'http://proxy.example.com:8080';
+  const client = new TelegramClient();
+
+  assert.strictEqual(usesProxy(client), true);
+  assert.strictEqual(client.telegram.options.agent.proxy.href, 'http://proxy.example.com:8080/');
+  delete process.env.HTTPS_PROXY;
+});
+
+test('the lowercase spelling works too', () => {
+  process.env.https_proxy = 'http://proxy.example.com:3128';
+  const client = new TelegramClient();
+
+  assert.strictEqual(usesProxy(client), true);
+  assert.strictEqual(client.telegram.options.agent.proxy.port, '3128');
+  delete process.env.https_proxy;
+});


### PR DESCRIPTION
Reimplements the proxy support proposed by @Fatpandac in #116, on top of the current code.

## Why it is needed

node-fetch, which telegraf sends through, does not read the proxy environment variables by itself. On a host that reaches the internet through a proxy the notifier cannot talk to Telegram at all.

## Why not merge #116 directly

Two reasons. The first is a blocker:

```js
agent: new HttpsProxyAgent(process.env.HTTPS_PROXY || null)
```

The agent is built unconditionally, so when `HTTPS_PROXY` is unset the constructor is handed `null`. Tested against `https-proxy-agent@7.0.6`:

```
null      → TypeError: Cannot read properties of null (reading 'href')
undefined → TypeError: Cannot read properties of undefined (reading 'href')
""        → TypeError: Invalid URL
```

That throws before anything else runs, so the container would fail to start for everyone who is not behind a proxy — which is nearly everyone.

The second is age: #116 predates the phase 2 to 5 work and now conflicts in `telegram.js`, `package.json` and `package-lock.json`. Rebasing it would have been more work than writing the three lines against the current file, so #116 is closed with an explanation rather than left waiting further.

## What this does

The agent is built only when a proxy is actually configured, so the default path is untouched and telegraf keeps its own keep-alive agent. `HTTPS_PROXY` and `https_proxy` are both accepted, since both spellings are in common use. An unusable URL is reported with exit code 100 instead of a stack trace, consistent with the other configuration errors.

## Verification

Four tests: no proxy leaves telegraf's default agent in place and does not throw, an empty value counts as unset, a configured proxy produces an `HttpsProxyAgent` with the right target, and the lowercase spelling works. Suite is at 38 tests.

Worth noting for the test itself: telegraf always supplies an agent of its own, so "no proxy configured" means that default stays rather than there being no agent — asserting `undefined` there would pass for the wrong reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpQu4cAwjJddpMec8Agd4p