### PR TITLE
Prepare 1.6.0-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docker-telegram-notifier",
-  "version": "1.5.0",
+  "version": "1.6.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docker-telegram-notifier",
-      "version": "1.5.0",
+      "version": "1.6.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "dockerode": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-telegram-notifier",
-  "version": "1.5.0",
+  "version": "1.6.0-beta.1",
   "description": "Docker container to inform you about docker-events via telegram",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Proxy support is a new feature, so this is a minor rather than a patch.

It goes out as a prerelease first because the proxy path cannot be exercised meaningfully from here — only by someone who actually sits behind one. @Fatpandac, who proposed it in #116, will be asked to try the beta image.

This is also the first time the beta path in the build workflow is used at all, so the tag it produces is worth watching rather than assuming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpQu4cAwjJddpMec8Agd4p