### PR TITLE
Tag betas without the leading v

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -56,7 +56,9 @@ jobs:
             type=semver,pattern={{version}},value=${{ steps.target.outputs.version }},enable=${{ !contains(steps.target.outputs.version, '-beta') }}
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.target.outputs.version }},enable=${{ !contains(steps.target.outputs.version, '-beta') }}
             type=semver,pattern={{major}},value=${{ steps.target.outputs.version }},enable=${{ !contains(steps.target.outputs.version, '-beta') }}
-            type=match,pattern=v\d+\.\d+\.\d+-beta\.\d+,group=0,value=${{ steps.target.outputs.version }}
+            # group 1 drops the leading v, so a beta is tagged 1.6.0-beta.1 and
+            # matches how the stable tags are written.
+            type=match,pattern=v(\d+\.\d+\.\d+-beta\.\d+),group=1,value=${{ steps.target.outputs.version }}
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0


### PR DESCRIPTION
`group=0` returned the whole match, so v1.6.0-beta.1 was published to Docker Hub as `v1.6.0-beta.1` while every stable tag is written without the prefix — `1.5.0`, `1.5`, `1`. Capturing the version rather than the whole match makes them consistent.

```
v1.6.0-beta.1   -> 1.6.0-beta.1
v1.6.0-beta.12  -> 1.6.0-beta.12
v1.5.0          -> no match (as before, semver handles it)
```

After merging I will rebuild v1.6.0-beta.1 through `workflow_dispatch` so the correctly named tag exists, rather than burning a beta.2 on a tag name.

---

**Separate observation, not fixed here.** The beta handling keys on the literal string `-beta`:

```yaml
latest=${{ !contains(steps.target.outputs.version, '-beta') }}
type=semver,...,enable=${{ !contains(steps.target.outputs.version, '-beta') }}
```

A prerelease tagged `-rc.1` or `-alpha.1` therefore does not count as a prerelease anywhere: the semver tags would be enabled and `latest` would move to it, while the `type=match` pattern would not produce a tag either. A release candidate would silently become `latest`.

Worth fixing, but it is a different change from the one asked for here — happy to do it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpQu4cAwjJddpMec8Agd4p