### PR TITLE
Fix up the coverage badge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,11 @@ jobs:
   # it, and so it never runs for a pull request from a fork.
   badge:
     if: github.event_name == 'push'
+    # The badge branch is force-pushed, so the newest push has to be the one
+    # that wins the race; an older, slower job must not overwrite it.
+    concurrency:
+      group: coverage-badge
+      cancel-in-progress: true
     needs: test
     runs-on: ubuntu-latest
     permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode/
 /node_modules
 *BAK*
-*BAK.*lcov.info
+*BAK.*
+lcov.info
 coverage.json

--- a/scripts/coverage-badge.js
+++ b/scripts/coverage-badge.js
@@ -19,11 +19,22 @@ try {
   process.exit(1);
 }
 
+// A truncated report would otherwise poison the sums with NaN, which slips
+// past the "no records at all" check below and publishes a "NaN%" badge.
+const count = (value) => {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) {
+    console.error(`Malformed line record in ${lcovPath}: ${JSON.stringify(value)}`);
+    process.exit(1);
+  }
+  return parsed;
+};
+
 let found = 0;
 let hit = 0;
 for (const line of report.split('\n')) {
-  if (line.startsWith('LF:')) found += Number.parseInt(line.slice(3), 10);
-  else if (line.startsWith('LH:')) hit += Number.parseInt(line.slice(3), 10);
+  if (line.startsWith('LF:')) found += count(line.slice(3));
+  else if (line.startsWith('LH:')) hit += count(line.slice(3));
 }
 
 if (found === 0) {
@@ -31,7 +42,9 @@ if (found === 0) {
   process.exit(1);
 }
 
-const percent = (hit / found) * 100;
+// Rounded once, so the colour cannot disagree with the number next to it:
+// 89.7% reads as "90%" and has to be brightgreen, not green.
+const percent = Math.round((hit / found) * 100);
 
 // The colour has to be decided here: shields only applies its own scale to
 // its built-in badges, not to endpoint ones.
@@ -45,7 +58,7 @@ const colour =
 const badge = {
   schemaVersion: 1,
   label: 'coverage',
-  message: `${percent.toFixed(0)}%`,
+  message: `${percent}%`,
   color: colour
 };
 


### PR DESCRIPTION
Follow-ups to the coverage badge merged in #150. This branch had been rewritten after that PR landed, which is what made it conflict; it is now rebased on `main` and carries only the three fixes below.

**`lcov.info` was never ignored.** Two lines in `.gitignore` had been folded into one, so the pattern read `*BAK.*lcov.info` and matched neither the backup files nor the report. Every `npm run coverage` left an untracked `lcov.info` behind.

**A malformed report could publish a `NaN%` badge.** A truncated lcov record parsed to `NaN` and poisoned the sums, which then slid past the "no records at all" check. Counts are validated as they are read and the script aborts instead.

**The colour could disagree with the number next to it.** The percentage is now rounded once, before the colour is picked, so 89.7% prints as "90%" and gets brightgreen rather than the green the unrounded comparison chose.

**Two pushes could race for the badge.** The `badges` branch is force-pushed rather than appended to, so a slower older job could overwrite a newer badge. A `coverage-badge` concurrency group with `cancel-in-progress` cancels the older run.

Verified locally: `npm run coverage` followed by the badge script writes `63%` / yellow, a truncated report exits 1 with the offending value named, and both generated files are now ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01As4LNGi5jFdp4KpBbW22gX
