### PR TITLE
Prepare 1.6.0-beta.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docker-telegram-notifier",
-  "version": "1.6.0-beta.1",
+  "version": "1.6.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docker-telegram-notifier",
-      "version": "1.6.0-beta.1",
+      "version": "1.6.0-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
         "dockerode": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-telegram-notifier",
-  "version": "1.6.0-beta.1",
+  "version": "1.6.0-beta.2",
   "description": "Docker container to inform you about docker-events via telegram",
   "repository": {
     "type": "git",


### PR DESCRIPTION
`beta.1` was cut before #152, so it still carries `https-proxy-agent` 7.0.6 while `main` is now on 9.1.0. The proxy path is the entire reason this prerelease exists, so the version testers run has to be the version that ships — hence a second beta rather than folding an untested major bump into the final 1.6.0.

Also picked up since `beta.1`: the beta Docker tag fix (#149) and the coverage badge (#150, #151).

Publishing the release triggers `docker-build`, which will push the `1.6.0-beta.2` image tag and leave `latest` alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQbcpQxbzX4xvkc6Ht93ek