### PR TITLE
Make the token and chat id usable as Portainer/swarm secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,38 @@ secrets:
     file: ./telegram_bot_token.txt
 ```
 
-`TELEGRAM_NOTIFIER_CHAT_ID_FILE` works the same way. A trailing newline in the file is ignored. If the file cannot be read, the container stops immediately with exit code 100 and names the file it tried to open.
+`TELEGRAM_NOTIFIER_CHAT_ID_FILE` works the same way. A trailing newline in the file is ignored, so `echo` into a file is fine.
+
+If the file cannot be read, or turns out to be empty, the container stops immediately with exit code 100 and names the file it tried to open. Both cases are reported as what they are rather than as a missing variable, because the environment is the wrong place to go looking when the secret is the part that is wrong.
+
+#### On Swarm and in Portainer
+
+`file:` reads a path next to the compose file. A swarm stack has no such path — and in Portainer the stack is pasted in as text — so the secret is created on a manager first and referenced as external:
+
+```bash
+printf '%s' '<bot_token>' | docker secret create telegram_bot_token -
+```
+
+`printf` rather than `echo`, so no newline travels with the token in the first place.
+
+```yaml
+services:
+  telegram-notifier:
+    image: lorcas/docker-telegram-notifier:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      TELEGRAM_NOTIFIER_BOT_TOKEN_FILE: /run/secrets/telegram_bot_token
+      TELEGRAM_NOTIFIER_CHAT_ID: <chat_id>
+    secrets:
+      - telegram_bot_token
+
+secrets:
+  telegram_bot_token:
+    external: true
+```
+
+Swarm mounts the secret at `/run/secrets/<name>` in every task, so the same stack works whatever node a replica lands on. Rotating the token means creating a second secret and pointing the service at it: a secret's content cannot be changed in place.
 
 
 ### 2.7 Outbound proxy

--- a/README.md
+++ b/README.md
@@ -259,6 +259,13 @@ secrets:
 
 Swarm mounts the secret at `/run/secrets/<name>` in every task, so the same stack works whatever node a replica lands on. Rotating the token means creating a second secret and pointing the service at it: a secret's content cannot be changed in place.
 
+Passing the token in the environment keeps working and is not going away. A container started that way notes the alternative once in its log — once per start, never from the healthcheck:
+
+```
+Note: TELEGRAM_NOTIFIER_BOT_TOKEN is set in the environment, where `docker inspect` can read it.
+TELEGRAM_NOTIFIER_BOT_TOKEN_FILE takes the token from a docker secret instead.
+```
+
 
 ### 2.7 Outbound proxy
 

--- a/app.js
+++ b/app.js
@@ -337,8 +337,12 @@ async function healthcheck() {
 }
 
 function checkConfiguration() {
+  // Both spellings are named: someone who configured the _FILE variant reads
+  // the bare name as "the secret never arrived" and starts looking in the
+  // wrong place, which is all they can see from a container log.
   const missing = ['TELEGRAM_NOTIFIER_BOT_TOKEN', 'TELEGRAM_NOTIFIER_CHAT_ID']
-    .filter(name => !process.env[name] || process.env[name].trim() === '');
+    .filter(name => !process.env[name] || process.env[name].trim() === '')
+    .map(name => `${name} (or ${name}_FILE)`);
 
   if (missing.length > 0) {
     console.error(`Missing required configuration: ${missing.join(', ')}`);

--- a/app.js
+++ b/app.js
@@ -351,6 +351,29 @@ function checkConfiguration() {
   }
 }
 
+/**
+ * A token in the environment is readable by anyone who can run
+ * `docker inspect` on the container. That is not new and nothing is broken by
+ * it, so this is a hint rather than an error — but it is worth saying once,
+ * because the setup that exposes the token is also the one everyone starts
+ * with and then never revisits.
+ *
+ * The chat id is deliberately not mentioned: without the token nobody can do
+ * anything with it, and naming both would blunt the one that matters.
+ *
+ * Returns the text rather than printing it, so the condition can be tested
+ * without capturing console output.
+ */
+function secretHint() {
+  if (process.env.TELEGRAM_NOTIFIER_BOT_TOKEN_FILE) return null;
+  if (!process.env.TELEGRAM_NOTIFIER_BOT_TOKEN) return null;
+
+  return 'Note: TELEGRAM_NOTIFIER_BOT_TOKEN is set in the environment, where ' +
+    '`docker inspect` can read it. TELEGRAM_NOTIFIER_BOT_TOKEN_FILE takes the ' +
+    'token from a docker secret instead.\n' +
+    'See https://github.com/luc-ass/docker-telegram-notifier#26-bot-token-from-a-file';
+}
+
 function handleError(e) {
   console.error(e);
   telegram.sendError(e).catch(console.error);
@@ -364,12 +387,18 @@ if (require.main === module) {
   if (process.argv.includes("healthcheck")) {
     healthcheck();
   } else {
+    // Start-up only. The healthcheck comes through this same file every 30
+    // seconds and would otherwise turn one hint into a log of its own.
+    const hint = secretHint();
+    if (hint) console.warn(hint);
+
     main().catch(handleError);
   }
 }
 
 module.exports = {
   envFlag,
+  secretHint,
   eventFilters,
   withEscapedAttributes,
   isNewEvent,

--- a/secrets.js
+++ b/secrets.js
@@ -19,12 +19,23 @@ function loadFileSettings(names) {
     const file = process.env[`${name}_FILE`];
     if (!file) continue;
 
+    let value;
     try {
-      process.env[name] = fs.readFileSync(file, 'utf8').trim();
+      value = fs.readFileSync(file, 'utf8').trim();
     } catch (e) {
       console.error(`Could not read ${name}_FILE at ${file}: ${e.message}`);
       process.exit(100);
     }
+
+    // An empty file would otherwise fall through to the configuration check,
+    // which can only report the variable as missing — and that sends people
+    // looking at the environment when the fault is in the secret itself.
+    if (value === '') {
+      console.error(`${name}_FILE at ${file} is empty`);
+      process.exit(100);
+    }
+
+    process.env[name] = value;
   }
 }
 

--- a/test/secrets.test.js
+++ b/test/secrets.test.js
@@ -63,3 +63,81 @@ test('an unreadable file stops the process and names the path', () => {
   assert.strictEqual(run.status, 100);
   assert.match(run.stderr, new RegExp(`Could not read DTN_TEST_TOKEN_FILE at ${file}`));
 });
+
+// Setups that keep the token in the environment stay supported; they are
+// pointed at the alternative once per start, and never told off for a setup
+// that is already correct.
+const { secretHint } = require('../app');
+
+function withEnv(env, run) {
+  const before = { ...process.env };
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  try {
+    return run();
+  } finally {
+    process.env = before;
+  }
+}
+
+test('a token in the environment is pointed at the file variant', () => {
+  const hint = withEnv({
+    TELEGRAM_NOTIFIER_BOT_TOKEN: '123:secret-token',
+    TELEGRAM_NOTIFIER_BOT_TOKEN_FILE: undefined
+  }, secretHint);
+
+  assert.match(hint, /TELEGRAM_NOTIFIER_BOT_TOKEN_FILE/);
+  // Whatever else the hint says, it must not carry the token into the log.
+  assert.doesNotMatch(hint, /123:secret-token/);
+});
+
+test('a token handed over as a file draws no hint', () => {
+  const hint = withEnv({
+    TELEGRAM_NOTIFIER_BOT_TOKEN: '123:secret-token',
+    TELEGRAM_NOTIFIER_BOT_TOKEN_FILE: '/run/secrets/telegram_bot_token'
+  }, secretHint);
+
+  assert.strictEqual(hint, null);
+});
+
+test('no hint when there is no token to talk about', () => {
+  const hint = withEnv({
+    TELEGRAM_NOTIFIER_BOT_TOKEN: undefined,
+    TELEGRAM_NOTIFIER_BOT_TOKEN_FILE: undefined
+  }, secretHint);
+
+  assert.strictEqual(hint, null);
+});
+
+// The hint belongs to start-up alone. The healthcheck enters through the same
+// file every 30 seconds, and a hint printed there would bury the log it is
+// supposed to be read in.
+function runApp(args) {
+  return spawnSync(process.execPath, [path.join(__dirname, '..', 'app.js'), ...args], {
+    env: {
+      PATH: process.env.PATH,
+      TELEGRAM_NOTIFIER_BOT_TOKEN: '123:secret-token',
+      TELEGRAM_NOTIFIER_CHAT_ID: '-100',
+      // Refused at once, so neither path waits on a daemon that isn't there.
+      DOCKER_HOST: 'tcp://127.0.0.1:1'
+    },
+    encoding: 'utf8',
+    timeout: 20000
+  });
+}
+
+test('start-up prints the hint once', () => {
+  const run = runApp([]);
+  assert.match(run.stdout + run.stderr, /Note: TELEGRAM_NOTIFIER_BOT_TOKEN is set in the environment/);
+});
+
+test('the healthcheck stays quiet about it', () => {
+  const run = runApp(['healthcheck']);
+  const output = run.stdout + run.stderr;
+
+  // It got far enough to have printed a hint, had one been there to print.
+  assert.match(output, /Docker is unavailable/);
+  assert.doesNotMatch(output, /Note: TELEGRAM_NOTIFIER_BOT_TOKEN/);
+});

--- a/test/secrets.test.js
+++ b/test/secrets.test.js
@@ -3,6 +3,7 @@ const assert = require('node:assert');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 const { loadFileSettings } = require('../secrets');
 
 test('a value handed over as a file replaces the variable', () => {
@@ -30,4 +31,35 @@ test('without the _FILE variant the environment is left alone', () => {
 test('a name that is set nowhere stays unset', () => {
   loadFileSettings(['DTN_TEST_ABSENT']);
   assert.strictEqual(process.env.DTN_TEST_ABSENT, undefined);
+});
+
+// loadFileSettings ends the process rather than throwing, so that a
+// misconfigured secret stops the container instead of letting it run on with
+// half a configuration. Testing that means running it in a child.
+function runWith(env) {
+  const module = path.join(__dirname, '..', 'secrets.js');
+  return spawnSync(process.execPath, [
+    '-e', `require(${JSON.stringify(module)}).loadFileSettings(['DTN_TEST_TOKEN'])`
+  ], { env: { ...process.env, ...env }, encoding: 'utf8' });
+}
+
+test('an empty file is reported as such, not as a missing variable', () => {
+  const file = path.join(os.tmpdir(), `dtn-empty-${process.pid}`);
+  fs.writeFileSync(file, '\n');
+
+  const run = runWith({ DTN_TEST_TOKEN_FILE: file });
+
+  assert.strictEqual(run.status, 100);
+  assert.match(run.stderr, /is empty/);
+  assert.match(run.stderr, new RegExp(file));
+  fs.unlinkSync(file);
+});
+
+test('an unreadable file stops the process and names the path', () => {
+  const file = path.join(os.tmpdir(), `dtn-absent-${process.pid}`);
+
+  const run = runWith({ DTN_TEST_TOKEN_FILE: file });
+
+  assert.strictEqual(run.status, 100);
+  assert.match(run.stderr, new RegExp(`Could not read DTN_TEST_TOKEN_FILE at ${file}`));
 });


### PR DESCRIPTION
`*_FILE` support already exists for `TELEGRAM_NOTIFIER_BOT_TOKEN` and `TELEGRAM_NOTIFIER_CHAT_ID`. What was missing was the swarm/Portainer half of it: the documented setup does not work there, and a mistake in the wiring is reported in a way that points at the wrong thing.

- **A broken secret file is reported as such.** An empty file used to fall through to the configuration check, which can only say the variable is missing. Both the empty and the unreadable case now stop the container with exit 100 and name the file. The unreadable path was already there but untested; both exits are now covered.
- **The error names the `_FILE` variant.** `TELEGRAM_NOTIFIER_BOT_TOKEN (or TELEGRAM_NOTIFIER_BOT_TOKEN_FILE)` — in Portainer the container log is all you have to go on.
- **README 2.6 covers swarm and Portainer.** The example used compose's `file:`, which reads a path next to the compose file. A swarm stack has no such path and a Portainer stack is pasted in as text, so the secret is created on a manager with `docker secret create` and referenced as `external: true`.
- **A token in the environment gets a one-line hint on start-up.** Naming the file variant and why it exists. It names only the token: without it the chat id is of no use to anyone. Start-up only — `checkConfiguration` runs for the healthcheck as well, which comes around every 30 seconds.

Passing the token in the environment keeps working exactly as before and is not deprecated. No new dependency.

`npm test`: 45 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQbcpQxbzX4xvkc6Ht93ek