### PR TITLE
Set version to 1.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docker-telegram-notifier",
-  "version": "1.6.0-beta.2",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docker-telegram-notifier",
-      "version": "1.6.0-beta.2",
+      "version": "1.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "dockerode": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-telegram-notifier",
-  "version": "1.6.0-beta.2",
+  "version": "1.7.0",
   "description": "Docker container to inform you about docker-events via telegram",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Cuts 1.7.0. The line closes out the 1.6.0 betas, which never went final.

Contents:

- #154 — swarm support: service, slot and node in the templates, and the service/node named instead of the task id
- #155 — token and chat id as Portainer/swarm secrets, with a clearer report when a secret file is broken

**Merge this after #154 and #155**, otherwise `main` carries the version without the changes it names. This branch touches only `package.json` and `package-lock.json`, so it merges cleanly whenever those land.

The image build runs on release publish, not on a tag push — publishing the GitHub release for `v1.7.0` is what produces `latest`, `1.7.0`, `1.7` and `1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQbcpQxbzX4xvkc6Ht93ek