### PR TITLE
Split the README into a docs/ folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,237 +1,19 @@
-<!-- omit in toc -->
 # Docker Telegram Notifier
-<!-- omit in toc -->
-# [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/luc-ass/docker-telegram-notifier/docker-image.yml?branch=main&style=for-the-badge)](https://github.com/luc-ass/docker-telegram-notifier/actions) [![Docker Pulls](https://img.shields.io/docker/pulls/lorcas/docker-telegram-notifier?logo=docker&style=for-the-badge)](https://hub.docker.com/r/lorcas/docker-telegram-notifier) [![Docker Image Version (latest semver)](https://img.shields.io/docker/v/lorcas/docker-telegram-notifier?logo=docker&style=for-the-badge)](https://github.com/luc-ass/docker-telegram-notifier/releases) [![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fluc-ass%2Fdocker-telegram-notifier%2Fbadges%2Fcoverage.json&style=for-the-badge)](https://github.com/luc-ass/docker-telegram-notifier/actions/workflows/test.yml)
 
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/luc-ass/docker-telegram-notifier/docker-image.yml?branch=main&style=for-the-badge)](https://github.com/luc-ass/docker-telegram-notifier/actions) [![Docker Pulls](https://img.shields.io/docker/pulls/lorcas/docker-telegram-notifier?logo=docker&style=for-the-badge)](https://hub.docker.com/r/lorcas/docker-telegram-notifier) [![Docker Image Version (latest semver)](https://img.shields.io/docker/v/lorcas/docker-telegram-notifier?logo=docker&style=for-the-badge)](https://github.com/luc-ass/docker-telegram-notifier/releases) [![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fluc-ass%2Fdocker-telegram-notifier%2Fbadges%2Fcoverage.json&style=for-the-badge)](https://github.com/luc-ass/docker-telegram-notifier/actions/workflows/test.yml)
 
-This Docker container provides a Telegram integration to notify you about Docker events. It can notify you when a container starts, stops (including details about exit codes) and when the healthcheck status of a Docker container changes. A restart is reported as a stop followed by a start, since that is what Docker emits. You have the flexibility to customize these notifications by [modifying the `templates.js` file](#3-notification-messages-customization).
+Get a Telegram message when a docker container starts, stops or changes its
+healthcheck status. Stop notifications carry the exit code and how long the
+container ran; a restart arrives as a stop followed by a start, because that is
+what docker emits. Every message text is customisable.
 
-This fork was created to address security vulnerabilities and add support for
-- `linux/arm64` and
-- `linux/arm/v7` in addition to
-- `linux/amd64`.
+Runs on `linux/amd64`, `linux/arm64` and `linux/arm/v7`.
 
-> [!NOTE]
-> The image is built on `node:22-slim` rather than `node:lts-slim`. Node 24 dropped
-> support for 32-bit ARM, so tracking the `lts` tag would silently drop `linux/arm/v7`.
-> Node 22 receives security support until April 2027; `linux/arm/v7` support will be
-> reconsidered before then.
+## Quick start
 
-If you encounter any issues, please feel free to contribute by fixing them and opening a [pull request](https://github.com/luc-ass/docker-telegram-notifier/pulls) or reporting a new [issue](https://github.com/luc-ass/docker-telegram-notifier/issues).
-
-<!-- omit in toc -->
-## Table of contents
-- [1. Basic setup](#1-basic-setup)
-- [2. Advanced setup](#2-advanced-setup)
-  - [2.1 Topics and Threads](#21-topics-and-threads)
-  - [2.2 Blacklisting](#22-blacklisting)
-  - [2.3 Whitelisting](#23-whitelisting)
-  - [2.4 Per container notifications](#24-per-container-notifications)
-  - [2.5 Remote docker instance](#25-remote-docker-instance)
-  - [2.6 Bot token from a file](#26-bot-token-from-a-file)
-  - [2.7 Outbound proxy](#27-outbound-proxy)
-- [3. Notification messages customization](#3-notification-messages-customization)
-  - [3.1 Create a custom template](#31-create-a-custom-template)
-  - [3.2 Customizing message strings](#32-customizing-message-strings)
-  - [3.2.1 Default docker event variables](#321-default-docker-event-variables)
-  - [3.2.2 Docker Compose variables](#322-docker-compose-variables)
-  - [3.2.3 Custom container information in Telegram notifications](#323-custom-container-information-in-telegram-notifications)
-- [4. Securing the docker socket](#4-securing-the-docker-socket)
-- [Credits](#credits)
-
-
-## 1. Basic setup
-
-1. **Set up a Telegram bot**
-
-    - [create a Telegram bot](https://core.telegram.org/bots#3-how-do-i-create-a-bot) and obtain the Bot Token
-    - optionally add the bot to a group and allow it to post messages
-    - extract the [Chat ID](https://stackoverflow.com/a/32572159/882223)
-
-2. **Run the container**
-
-    using `docker-compose.yaml`
-    ```yaml
-    services:
-      telegram-notifier:
-        image: lorcas/docker-telegram-notifier:latest
-        volumes:
-            - /var/run/docker.sock:/var/run/docker.sock:ro # for local instance
-        environment:
-          TELEGRAM_NOTIFIER_BOT_TOKEN: <bot_token>
-          TELEGRAM_NOTIFIER_CHAT_ID: <chat_id>
-    ```
-
-    using `docker run`
-    ```sh
-    docker run -d \
-      --env TELEGRAM_NOTIFIER_BOT_TOKEN=<bot_token> \
-      --env TELEGRAM_NOTIFIER_CHAT_ID=<chat_id> \
-      --volume /var/run/docker.sock:/var/run/docker.sock:ro \
-      --hostname my_host \
-      lorcas/docker-telegram-notifier
-    ```
-
-3. **Add a healthcheck to your container** (optional)
-
-    ```yaml
-    example:
-      image: hello-world
-      healthcheck:
-        test: ["CMD", "curl", "-sS", "http://127.0.0.1:8545", "||", "exit", "1"]
-        interval: 30s
-        timeout: 10s
-        retries: 3
-    ```
-
-This setup will start the container and notify you about Docker events. For more advanced configuration, see the [Advanced setup](#2-advanced-setup) section.
-
-
-## 2. Advanced setup
-
-The following options are available to customize the behavior of the notifier. Examples are provided for `docker-compose.yaml` but are also applicable to `docker run`. Only the changes are shown, make sure to include the rest from the [Basic setup](#1-basic-setup) section.
-
-### 2.1 Topics and Threads
-
-Use `TELEGRAM_NOTIFIER_TOPIC_ID` or `TELEGRAM_NOTIFIER_THREAD_ID` for specific topics/threads:
-
-```yaml
-services:
-  telegram-notifier:
-    environment:
-      TELEGRAM_NOTIFIER_TOPIC_ID: <topic_id> # optional use only one
-      TELEGRAM_NOTIFIER_THREAD_ID: <thread_id> # optional use only one
-```
-
-### 2.2 Blacklisting
-Disable notifications for specific containers:
-
-
-```yaml
-services:
-  example:
-    image: hello-world
-    labels:
-      telegram-notifier.monitor: false
-```
-
-<details>
-<summary>
-docker run
-</summary>
-
-```sh
-docker run -d --label telegram-notifier.monitor=false hello-world
-```
-</details>
-
-
-### 2.3 Whitelisting
-
-Receive notifications only from whitelisted containers by setting `ONLY_WHITELIST=true` and labeling desired containers. The variable is off unless set to a value other than `false`, `0`, `no` or `off`:
-
-```yaml
-services:
-  telegram-notifier:
-    environment:
-      ONLY_WHITELIST: true
-
-  example:
-    image: hello-world
-    labels:
-      telegram-notifier.monitor: true
-```
-<details>
-<summary>
-docker run
-</summary>
-
-```sh
-docker run -d --label telegram-notifier.monitor=true hello-world
-```
-</details>
-
-### 2.4 Per container notifications
-
-Configure different channels/threads per container:
-
-```yaml
-services:
-  example:
-    image: hello-world
-    labels:
-      # Channel override (optional)
-      telegram-notifier.chat-id: "-100123456789"
-      # Thread/Topic override (optional - use only one)
-      telegram-notifier.topic-id: "12345"
-      #                         : "false" # would explicitely override to use NONE
-      telegram-notifier.thread-id: "12345"
-      #                          : "" # would also explicitely override to use NONE
-```
-
-> [!IMPORTANT]
-> When leaving away a `.topic-id` / `.thread-id` label, but having one defined globally as per [Topics and Threads](#21-topics-and-threads), then that will be **used automatically as fallback**.
-> If that is unintended, you have to explicitely set the label to EMPTY (or `false`).
-> - Example scenario: when for example the per container `chat-id` differs from the global, and has NO Topics / Threads support.
-
-<details>
-<summary>
-docker run
-</summary>
-
-```sh
-docker run -d --label telegram-notifier.chat-id=-100123456789 --label telegram-notifier.topic-id=12345 hello-world
-```
-</details>
-
-
-### 2.5 Remote docker instance
-
-By default notifier connects to a local docker instance (don't forget to specify `--volume /var/run/docker.sock:/var/run/docker.sock:ro` for this case). But if you have monitoring and the service on the same host, you will not receive notifications if the host goes down. So I recommend to have monitoring separately.
-
-Notifier accepts usual `DOCKER_HOST` and `DOCKER_CERT_PATH` environment variables to specify remote instance. For http endpoint you need to specify only `--env DOCKER_HOST=tcp://example.com:2375` (make sure to keep such instances behind the firewall). For https, you'll also need to mount a volume with https certificates that contains `ca.pem`, `cert.pem`, and `key.pem`: `--env DOCKER_HOST=tcp://example.com:2376 --env DOCKER_CERT_PATH=/certs --volume $(pwd):/certs`.
-A tutorial on how to generate docker certs can be found [here](https://docs.docker.com/engine/security/https/).
-
-```yaml
-services:
-  telegram-notifier:
-    volumes:
-      # disable for remote ONLY monitoring
-      # - /var/run/docker.sock:/var/run/docker.sock:ro
-      - ./certs:/certs # for remote instance
-    environment:
-      DOCKER_HOST: tcp://example.com:2376 # http/https is detected by port number
-      DOCKER_CERT_PATH: /certs # should contain ca.pem, cert.pem, key.pem
-```
-
-
-### 2.6 Bot token from a file
-
-Environment variables are readable by anyone who can run `docker inspect` on the container. To keep the bot token out of them, append `_FILE` to the variable name and point it at a file:
-
-```yaml
-services:
-  telegram-notifier:
-    image: lorcas/docker-telegram-notifier:latest
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-    environment:
-      TELEGRAM_NOTIFIER_BOT_TOKEN_FILE: /run/secrets/telegram_bot_token
-      TELEGRAM_NOTIFIER_CHAT_ID: <chat_id>
-    secrets:
-      - telegram_bot_token
-
-secrets:
-  telegram_bot_token:
-    file: ./telegram_bot_token.txt
-```
-
-`TELEGRAM_NOTIFIER_CHAT_ID_FILE` works the same way. A trailing newline in the file is ignored. If the file cannot be read, the container stops immediately with exit code 100 and names the file it tried to open.
-
-
-### 2.7 Outbound proxy
-
-If the host reaches the internet through a proxy, set `HTTPS_PROXY` and the notifier will send its Telegram requests through it:
+[Create a Telegram bot](https://core.telegram.org/bots#3-how-do-i-create-a-bot),
+grab its token and your [chat ID](https://stackoverflow.com/a/32572159/882223),
+then:
 
 ```yaml
 services:
@@ -242,208 +24,47 @@ services:
     environment:
       TELEGRAM_NOTIFIER_BOT_TOKEN: <bot_token>
       TELEGRAM_NOTIFIER_CHAT_ID: <chat_id>
-      HTTPS_PROXY: http://proxy.example.com:8080
 ```
 
-<details>
-<summary>
-docker run
-</summary>
+That's it — every container on the host is reported from now on.
 
-```sh
-docker run -d \
-  --env TELEGRAM_NOTIFIER_BOT_TOKEN=<bot_token> \
-  --env TELEGRAM_NOTIFIER_CHAT_ID=<chat_id> \
-  --env HTTPS_PROXY=http://proxy.example.com:8080 \
-  --volume /var/run/docker.sock:/var/run/docker.sock:ro \
-  lorcas/docker-telegram-notifier
-```
-</details>
+## Documentation
 
-The lowercase `https_proxy` is accepted as well. This only affects the connection to Telegram; the docker socket is not reached over the network. An unusable proxy URL stops the container with exit code 100.
+| Page | What it covers |
+| :--- | :--- |
+| [Basic setup](docs/basic-setup.md) | Create the bot, run the container, add a healthcheck |
+| [Environment variables](docs/environment-variables.md) | Every variable the notifier reads |
+| [Container labels](docs/container-labels.md) | Every label the notifier reads |
+| [Filtering containers](docs/filtering-containers.md) | Blacklisting and whitelisting |
+| [Chats, topics and threads](docs/chats-and-topics.md) | Global routing and per-container overrides |
+| [Remote docker and proxies](docs/remote-docker-and-proxy.md) | `DOCKER_HOST`, TLS certificates, outbound proxy |
+| [Secrets](docs/secrets.md) | Keeping the bot token out of the environment |
+| [Custom message templates](docs/custom-templates.md) | Rewriting the notification texts |
+| [Securing the docker socket](docs/securing-the-docker-socket.md) | Why `:ro` is not enough, and what to do instead |
 
+> [!WARNING]
+> Mounting the docker socket read-only protects the socket file, not the API
+> behind it — anything that reaches it can take over the host. See
+> [Securing the docker socket](docs/securing-the-docker-socket.md) for the
+> socket-proxy setup.
 
-## 3. Notification messages customization
+## Contributing
 
-### 3.1 Create a custom template
+Found a bug or missing a feature? Open an
+[issue](https://github.com/luc-ass/docker-telegram-notifier/issues) or a
+[pull request](https://github.com/luc-ass/docker-telegram-notifier/pulls).
+Security reports go through [SECURITY.md](SECURITY.md).
 
-1. __Adapt the template:__ download and modify the message strings from [`templates.js`](./templates.js) according to your needs.
+## Notes
 
-2. __Bind your customized file to the container:__
-
-    using `docker-compose.yaml`
-    ```yaml
-    services:
-      notifier:
-        volumes:
-          # Bind customized file to templates.js in the container:
-          - ./my-template.js:/usr/src/app/templates.js:ro
-        environment:
-          # ...
-    ```
-
-    <details>
-    <summary>
-    docker run
-    </summary>
-
-    ```sh
-    docker run -d \
-        --env TELEGRAM_NOTIFIER_BOT_TOKEN=token \
-        --env TELEGRAM_NOTIFIER_CHAT_ID=chat_id \
-        --volume /var/run/docker.sock:/var/run/docker.sock:ro \
-        --volume ./my-template.js:/usr/src/app/templates.js:ro \
-        --hostname my_host \
-        lorcas/docker-telegram-notifier
-    ```
-    </details>
-
-### 3.2 Customizing message strings
-
-### 3.2.1 Default docker event variables
-
-Here are some variables available to customize the notification messages.
-
-| Variable | Description |
-| :-------- | :----------- |
-| `${e.Actor.ID}` | Container ID (full, 64 characters) |
-| `${e.Actor.Attributes.name}` | Container name |
-| `${e.Actor.Attributes.image}` | Container image used |
-| `${e.Actor.Attributes.exitCode}` | Container exit code (`die` events only) |
-| `${e.Actor.Attributes.execDuration}` | Seconds the container ran (`die` events only) |
-
-Beyond those, **every label on the container is available under the same path**, which is what makes [custom container information](#323-custom-container-information-in-telegram-notifications) work. That includes the labels `docker compose` adds by itself, listed below.
-
-`Attributes` is a plain object, so values are `undefined` when the event does not carry them — `exitCode` on a `start` event, for instance. The authoritative list of what an event can contain is the [Docker Engine API](https://docs.docker.com/reference/api/engine/version/v1.51/#tag/System/operation/SystemEvents); the notifier passes it through unchanged, apart from HTML-escaping the values.
-
-Example:
-```js
-container_start: e =>
-    `&#9989; Container Started\n` +
-    `Name: <b>${e.Actor.Attributes.name}</b>\n` +
-    `Image: <code>${e.Actor.Attributes.image}</code>\n` +
-    `ID: <code>${e.Actor.ID.slice(0, 12)}</code>`
-```
-```
-🟢 Container Started
-Name: my-container
-Image: nginx:latest
-ID: abc123def456
-```
-
-
-### 3.2.2 Docker Compose variables
-
-The following variables are only available if the container was started using `docker compose`
-| Variable | Description |
-| :-------- | :----------- |
-| `${e.Actor.Attributes['com.docker.compose.container-number']}` | Compose container Number |
-| `${e.Actor.Attributes['com.docker.compose.project']}` | Compose Project Name |
-| `${e.Actor.Attributes['com.docker.compose.service']}` | Compose Service Name |
-| `${e.Actor.Attributes['com.docker.compose.version']}` | Compose Version |
-
-Compose adds more than these — `com.docker.compose.config-hash`, `com.docker.compose.image`, `com.docker.compose.oneoff`, `com.docker.compose.project.config_files` and `com.docker.compose.project.working_dir` are present as well. They are ordinary labels, so they are reached the same way.
-
-Example:
-```js
-container_start: e =>
-    `&#9989; Container Started\n` +
-    `Project: <b>${e.Actor.Attributes['com.docker.compose.project']}</b>\n` +
-    `Service: <b>${e.Actor.Attributes['com.docker.compose.service']}</b> (#${e.Actor.Attributes['com.docker.compose.container-number']})\n` +
-    `Image: <code>${e.Actor.Attributes.image}</code>\n` +
-    `Compose Version: <code>${e.Actor.Attributes['com.docker.compose.version']}</code>`
-```
-```
-🟢 Container Started
-Project: myproject
-Service: webserver (#1)
-Image: nginx:latest
-Compose Version: 2.17.2
-```
-
-### 3.2.3 Custom container information in Telegram notifications
-
-Leverage the `labels:` defintion on docker services to make custom information available to notification messages:
-
-1. __Add custom labels to a container:__
-
-    using `docker-compose.yaml`
-    ```yaml
-    services:
-      example:
-        image: hello-world
-        labels:
-          # Monitor control
-          telegram-notifier.monitor: true
-          # Custom defined labels and information
-          mycustom.telegram.container-info: "Access via http://myhost.com/"
-    ```
-
-    using `docker run`:
-    ```sh
-    docker run -d \
-        --label "telegram-notifier.monitor=true" \
-        --label "mycustom.telegram.container-info=Access via http://myhost.com/" \
-        hello-world
-    ```
-
-
-2. __Adapt your customized messages template:__
-    ```js
-    container_start: e =>
-        `&#9654;&#65039; <b>${e.Actor.Attributes.name}</b> started\n` +
-        `Image: <code>${e.Actor.Attributes.image}</code>` +
-        (
-          e.Actor.Attributes['mycustom.telegram.container-info'] ?
-          `\nNOTE: ${e.Actor.Attributes['mycustom.telegram.container-info']}` :
-          ''
-        )
-    ```
-
-## 4. Securing the docker socket
-
-The basic setup mounts the docker socket read-only:
-
-```yaml
-volumes:
-  - /var/run/docker.sock:/var/run/docker.sock:ro
-```
-
-**`:ro` protects the socket file, not the API behind it.** Anything that can reach the docker socket can create a container, mount any host path into it and run it as root — so it can take over the host, read-only mount or not. That applies to every tool that reads docker events this way, this one included.
-
-This notifier only needs four read-only endpoints: `version`, `info`, `ping` and `events`. A socket proxy is a small container that exposes exactly those and refuses everything else:
-
-```yaml
-services:
-  docker-socket-proxy:
-    image: tecnativa/docker-socket-proxy:latest
-    environment:
-      EVENTS: 1   # the event stream itself
-      INFO: 1     # host details in the start-up message
-      PING: 1     # the healthcheck's liveness probe
-      VERSION: 1  # docker version in the start-up message
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-    restart: unless-stopped
-
-  telegram-notifier:
-    image: lorcas/docker-telegram-notifier:latest
-    depends_on:
-      - docker-socket-proxy
-    environment:
-      DOCKER_HOST: tcp://docker-socket-proxy:2375
-      TELEGRAM_NOTIFIER_BOT_TOKEN: <bot_token>
-      TELEGRAM_NOTIFIER_CHAT_ID: <chat_id>
-    restart: unless-stopped
-```
-
-The notifier gets no volume at all in this setup — it talks HTTP to the proxy, and the proxy is the only container holding the socket. Everything the proxy does not explicitly allow is refused, so a compromised notifier cannot create containers.
-
-Keep the proxy off any published port. It has no authentication, so anything that can reach it inherits its permissions.
-
-> This combination is tested: with those four permissions enabled and everything else at its default of off, both notifications and the healthcheck work. `PING` is easy to miss — the healthcheck uses it to tell a live daemon from a stalled event stream.
-
+The image is built on `node:22-slim` rather than `node:lts-slim`. Node 24
+dropped support for 32-bit ARM, so tracking the `lts` tag would silently drop
+`linux/arm/v7`. Node 22 receives security support until April 2027;
+`linux/arm/v7` support will be reconsidered before then.
 
 ## Credits
 
-This container is based on the [container by poma](https://hub.docker.com/r/poma/docker-telegram-notifier), originally an idea of [arefaslani](https://github.com/arefaslani).
+Based on the [container by
+poma](https://hub.docker.com/r/poma/docker-telegram-notifier), originally an
+idea of [arefaslani](https://github.com/arefaslani). Licensed under
+[Apache 2.0](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,13 +26,13 @@ Worth knowing before you deploy it, and relevant to how you judge a finding:
 
 - **The docker socket is full control of the host.** The documented setup
   mounts `/var/run/docker.sock` read-only, but `:ro` only protects the socket
-  file — the API behind it can still create privileged containers. Section 4
-  of the README describes running the notifier behind a socket proxy that
-  exposes only `version`, `info`, `ping` and `events`, which is the safer
-  arrangement.
+  file — the API behind it can still create privileged containers.
+  [docs/securing-the-docker-socket.md](docs/securing-the-docker-socket.md)
+  describes running the notifier behind a socket proxy that exposes only
+  `version`, `info`, `ping` and `events`, which is the safer arrangement.
 - **The bot token is a credential for your Telegram bot.** Passed as an
   environment variable it is readable through `docker inspect`. It can be
-  supplied as a file instead — see section 2.6 of the README.
+  supplied as a file instead — see [docs/secrets.md](docs/secrets.md).
 - **Container names, image tags and labels end up in messages.** They are
   HTML-escaped before being sent, so a container whose labels contain markup
   cannot break or forge the notification.

--- a/app.js
+++ b/app.js
@@ -59,7 +59,7 @@ const EVENT_FILTERS = eventFilters();
 
 /**
  * Attributes carry arbitrary user input: container names, image tags and any
- * custom label the README encourages people to add. Escaping them here covers
+ * custom label the docs encourage people to add. Escaping them here covers
  * every template, including the ones people mount themselves, instead of
  * asking each template to remember.
  */
@@ -342,7 +342,7 @@ function checkConfiguration() {
 
   if (missing.length > 0) {
     console.error(`Missing required configuration: ${missing.join(', ')}`);
-    console.error('See https://github.com/luc-ass/docker-telegram-notifier#1-basic-setup');
+    console.error('See https://github.com/luc-ass/docker-telegram-notifier/blob/main/docs/basic-setup.md');
     process.exit(100);
   }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,13 @@
+# Documentation
+
+| Page | What it covers |
+| :--- | :--- |
+| [Basic setup](basic-setup.md) | Create the bot, run the container, add a healthcheck |
+| [Environment variables](environment-variables.md) | Every variable the notifier reads |
+| [Container labels](container-labels.md) | Every label the notifier reads |
+| [Filtering containers](filtering-containers.md) | Blacklisting and whitelisting |
+| [Chats, topics and threads](chats-and-topics.md) | Global routing and per-container overrides |
+| [Remote docker and proxies](remote-docker-and-proxy.md) | `DOCKER_HOST`, TLS certificates, outbound proxy |
+| [Secrets](secrets.md) | Keeping the bot token out of the environment |
+| [Custom message templates](custom-templates.md) | Rewriting the notification texts |
+| [Securing the docker socket](securing-the-docker-socket.md) | Why `:ro` is not enough, and what to do instead |

--- a/docs/basic-setup.md
+++ b/docs/basic-setup.md
@@ -1,0 +1,66 @@
+# Basic setup
+
+## 1. Set up a Telegram bot
+
+- [Create a Telegram bot](https://core.telegram.org/bots#3-how-do-i-create-a-bot) and obtain the bot token
+- Optionally add the bot to a group and allow it to post messages
+- Extract the [chat ID](https://stackoverflow.com/a/32572159/882223)
+
+## 2. Run the container
+
+Using `docker-compose.yaml`:
+
+```yaml
+services:
+  telegram-notifier:
+    image: lorcas/docker-telegram-notifier:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro # for local instance
+    environment:
+      TELEGRAM_NOTIFIER_BOT_TOKEN: <bot_token>
+      TELEGRAM_NOTIFIER_CHAT_ID: <chat_id>
+```
+
+Using `docker run`:
+
+```sh
+docker run -d \
+  --env TELEGRAM_NOTIFIER_BOT_TOKEN=<bot_token> \
+  --env TELEGRAM_NOTIFIER_CHAT_ID=<chat_id> \
+  --volume /var/run/docker.sock:/var/run/docker.sock:ro \
+  --hostname my_host \
+  lorcas/docker-telegram-notifier
+```
+
+The `--hostname` shows up in the start-up message, which helps when several
+hosts report into the same chat.
+
+> [!WARNING]
+> Mounting the docker socket read-only protects the socket file, not the API
+> behind it. See [Securing the docker socket](securing-the-docker-socket.md).
+
+## 3. Add a healthcheck to your containers (optional)
+
+The notifier reports healthcheck transitions, but only for containers that
+define one:
+
+```yaml
+services:
+  example:
+    image: hello-world
+    healthcheck:
+      test: ["CMD", "curl", "-sS", "http://127.0.0.1:8545", "||", "exit", "1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+```
+
+## What you get
+
+The notifier reports when a container starts, when it stops (including the
+exit code and how long it ran) and when its healthcheck status changes. A
+restart arrives as a stop followed by a start, because that is what docker
+emits.
+
+From here, see [Environment variables](environment-variables.md) and
+[Container labels](container-labels.md) for the full set of knobs.

--- a/docs/chats-and-topics.md
+++ b/docs/chats-and-topics.md
@@ -1,0 +1,56 @@
+# Chats, topics and threads
+
+## Globally
+
+All notifications land in `TELEGRAM_NOTIFIER_CHAT_ID`. To put them into a
+specific forum topic or message thread, add one of:
+
+```yaml
+services:
+  telegram-notifier:
+    environment:
+      TELEGRAM_NOTIFIER_TOPIC_ID: <topic_id>   # use only one
+      TELEGRAM_NOTIFIER_THREAD_ID: <thread_id> # use only one
+```
+
+## Per container
+
+Individual containers can be routed elsewhere:
+
+```yaml
+services:
+  example:
+    image: hello-world
+    labels:
+      # Chat override (optional)
+      telegram-notifier.chat-id: "-100123456789"
+      # Thread/topic override (optional — use only one)
+      telegram-notifier.topic-id: "12345"
+      telegram-notifier.thread-id: "12345"
+```
+
+<details>
+<summary>docker run</summary>
+
+```sh
+docker run -d \
+  --label telegram-notifier.chat-id=-100123456789 \
+  --label telegram-notifier.topic-id=12345 \
+  hello-world
+```
+
+</details>
+
+> [!IMPORTANT]
+> A container without a `.topic-id` / `.thread-id` label **falls back to the
+> global setting**. If that is not what you want — say, the container posts
+> into a different chat that has no topics — set the label explicitly to an
+> empty value or `false` to turn it off for that container:
+>
+> ```yaml
+> telegram-notifier.topic-id: "false"
+> telegram-notifier.thread-id: ""
+> ```
+
+`topic-id` wins over `thread-id` when both are present. Telegram expects a
+positive integer here; a value it cannot parse is treated as no topic at all.

--- a/docs/container-labels.md
+++ b/docs/container-labels.md
@@ -1,0 +1,40 @@
+# Container labels
+
+These labels go on the containers you want to be notified about, not on the
+notifier itself.
+
+| Label | Description |
+| :--- | :--- |
+| `telegram-notifier.monitor` | `false` silences the container; `true` includes it when `ONLY_WHITELIST` is on |
+| `telegram-notifier.chat-id` | Send this container's events to a different chat |
+| `telegram-notifier.topic-id` | Forum topic for this container |
+| `telegram-notifier.thread-id` | Message thread for this container |
+
+`topic-id` wins over `thread-id` if both are set. An empty value, `false` or
+`0` explicitly disables the globally configured topic or thread for this
+container.
+
+Beyond these, **every** label on a container is available to the message
+templates, including the ones `docker compose` adds by itself. See
+[Custom message templates](custom-templates.md).
+
+## Where they go
+
+Using `docker-compose.yaml`:
+
+```yaml
+services:
+  example:
+    image: hello-world
+    labels:
+      telegram-notifier.monitor: true
+```
+
+Using `docker run`:
+
+```sh
+docker run -d --label telegram-notifier.monitor=true hello-world
+```
+
+Related: [Filtering containers](filtering-containers.md),
+[Chats, topics and threads](chats-and-topics.md).

--- a/docs/custom-templates.md
+++ b/docs/custom-templates.md
@@ -1,0 +1,130 @@
+# Custom message templates
+
+Every notification text lives in [`templates.js`](../templates.js). Replacing
+that file replaces the messages.
+
+## Using your own file
+
+1. Download [`templates.js`](../templates.js) and edit the message strings.
+2. Mount it over the one in the image:
+
+```yaml
+services:
+  telegram-notifier:
+    volumes:
+      - ./my-template.js:/usr/src/app/templates.js:ro
+```
+
+<details>
+<summary>docker run</summary>
+
+```sh
+docker run -d \
+  --env TELEGRAM_NOTIFIER_BOT_TOKEN=token \
+  --env TELEGRAM_NOTIFIER_CHAT_ID=chat_id \
+  --volume /var/run/docker.sock:/var/run/docker.sock:ro \
+  --volume ./my-template.js:/usr/src/app/templates.js:ro \
+  --hostname my_host \
+  lorcas/docker-telegram-notifier
+```
+
+</details>
+
+Messages are sent as Telegram HTML, so `<b>`, `<i>` and `<code>` work. Values
+coming from docker are HTML-escaped for you.
+
+The notifier subscribes to exactly the events it has a template for, derived
+from the template keys — so a mounted file that adds an event keeps receiving
+it.
+
+## Available variables
+
+### Docker event fields
+
+| Variable | Description |
+| :--- | :--- |
+| `${e.Actor.ID}` | Container ID (full, 64 characters) |
+| `${e.Actor.Attributes.name}` | Container name |
+| `${e.Actor.Attributes.image}` | Container image used |
+| `${e.Actor.Attributes.exitCode}` | Container exit code (`die` events only) |
+| `${e.Actor.Attributes.execDuration}` | Seconds the container ran (`die` events only) |
+
+`Attributes` is a plain object, so values are `undefined` when the event does
+not carry them — `exitCode` on a `start` event, for instance. The
+authoritative list of what an event can contain is the [Docker Engine
+API](https://docs.docker.com/reference/api/engine/version/v1.51/#tag/System/operation/SystemEvents);
+the notifier passes it through unchanged, apart from escaping the values.
+
+```js
+container_start: e =>
+    `&#9989; Container Started\n` +
+    `Name: <b>${e.Actor.Attributes.name}</b>\n` +
+    `Image: <code>${e.Actor.Attributes.image}</code>\n` +
+    `ID: <code>${e.Actor.ID.slice(0, 12)}</code>`
+```
+
+```
+🟢 Container Started
+Name: my-container
+Image: nginx:latest
+ID: abc123def456
+```
+
+### Docker Compose labels
+
+Present only on containers started by `docker compose`:
+
+| Variable | Description |
+| :--- | :--- |
+| `${e.Actor.Attributes['com.docker.compose.container-number']}` | Compose container number |
+| `${e.Actor.Attributes['com.docker.compose.project']}` | Compose project name |
+| `${e.Actor.Attributes['com.docker.compose.service']}` | Compose service name |
+| `${e.Actor.Attributes['com.docker.compose.version']}` | Compose version |
+
+Compose adds more than these — `config-hash`, `image`, `oneoff`,
+`project.config_files` and `project.working_dir` are there as well, under the
+same `com.docker.compose.` prefix.
+
+```js
+container_start: e =>
+    `&#9989; Container Started\n` +
+    `Project: <b>${e.Actor.Attributes['com.docker.compose.project']}</b>\n` +
+    `Service: <b>${e.Actor.Attributes['com.docker.compose.service']}</b> (#${e.Actor.Attributes['com.docker.compose.container-number']})\n` +
+    `Image: <code>${e.Actor.Attributes.image}</code>\n` +
+    `Compose Version: <code>${e.Actor.Attributes['com.docker.compose.version']}</code>`
+```
+
+```
+🟢 Container Started
+Project: myproject
+Service: webserver (#1)
+Image: nginx:latest
+Compose Version: 2.17.2
+```
+
+### Your own labels
+
+Every label on a container reaches the template under the same path, so any
+information you attach to a service can appear in its notifications:
+
+```yaml
+services:
+  example:
+    image: hello-world
+    labels:
+      mycustom.telegram.container-info: "Access via http://myhost.com/"
+```
+
+```js
+container_start: e =>
+    `&#9654;&#65039; <b>${e.Actor.Attributes.name}</b> started\n` +
+    `Image: <code>${e.Actor.Attributes.image}</code>` +
+    (
+      e.Actor.Attributes['mycustom.telegram.container-info'] ?
+      `\nNOTE: ${e.Actor.Attributes['mycustom.telegram.container-info']}` :
+      ''
+    )
+```
+
+Guard optional labels like that — containers without the label would otherwise
+report `undefined`.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,0 +1,64 @@
+# Environment variables
+
+## Required
+
+| Variable | Description |
+| :--- | :--- |
+| `TELEGRAM_NOTIFIER_BOT_TOKEN` | Token of the bot that sends the messages |
+| `TELEGRAM_NOTIFIER_CHAT_ID` | Chat the messages go to |
+
+Both accept a `_FILE` suffix instead, pointing at a file that holds the value.
+See [Secrets](secrets.md).
+
+## Routing
+
+| Variable | Default | Description |
+| :--- | :--- | :--- |
+| `TELEGRAM_NOTIFIER_TOPIC_ID` | — | Forum topic to post into. Use either this or `THREAD_ID`, not both |
+| `TELEGRAM_NOTIFIER_THREAD_ID` | — | Message thread to post into |
+
+Individual containers can override both. See
+[Chats, topics and threads](chats-and-topics.md).
+
+## Filtering
+
+| Variable | Default | Description |
+| :--- | :--- | :--- |
+| `ONLY_WHITELIST` | off | Report only containers labelled `telegram-notifier.monitor: true` |
+
+The flag counts as off when unset, empty, `false`, `0`, `no` or `off` — every
+other value turns it on. See [Filtering containers](filtering-containers.md).
+
+## Docker connection
+
+| Variable | Default | Description |
+| :--- | :--- | :--- |
+| `DOCKER_HOST` | local socket | Remote daemon, e.g. `tcp://example.com:2376` |
+| `DOCKER_CERT_PATH` | — | Directory holding `ca.pem`, `cert.pem` and `key.pem` for TLS |
+
+See [Remote docker and proxies](remote-docker-and-proxy.md).
+
+## Network
+
+| Variable | Default | Description |
+| :--- | :--- | :--- |
+| `HTTPS_PROXY` | — | Proxy for the connection to Telegram. Lowercase `https_proxy` works too |
+
+An unusable proxy URL stops the container with exit code 100.
+
+## Tuning
+
+| Variable | Default | Description |
+| :--- | :--- | :--- |
+| `TELEGRAM_NOTIFIER_SEND_INTERVAL_MS` | `1000` | Minimum gap between two messages |
+| `TELEGRAM_NOTIFIER_HEARTBEAT_FILE` | `<tmpdir>/docker-telegram-notifier.heartbeat` | Where the healthcheck's liveness marker is written |
+
+Telegram accepts roughly 20 messages per minute into one group, so sends are
+spaced out rather than fired as fast as docker reports them. A backlog longer
+than 200 messages is dropped instead of kept in memory. Lower the interval only
+if you know the chat can take it.
+
+The heartbeat file is refreshed every 30 seconds by asking the daemon for a
+ping; the container's healthcheck fails once it is older than 90 seconds. This
+catches a docker connection that has gone quiet without the process exiting.
+Point the variable elsewhere if `/tmp` is read-only in your setup.

--- a/docs/filtering-containers.md
+++ b/docs/filtering-containers.md
@@ -1,0 +1,54 @@
+# Filtering containers
+
+By default every container on the host is reported. There are two ways to
+narrow that down.
+
+## Blacklisting
+
+Silence individual containers and leave the rest alone:
+
+```yaml
+services:
+  example:
+    image: hello-world
+    labels:
+      telegram-notifier.monitor: false
+```
+
+<details>
+<summary>docker run</summary>
+
+```sh
+docker run -d --label telegram-notifier.monitor=false hello-world
+```
+
+</details>
+
+## Whitelisting
+
+Report nothing except the containers you opt in. Set `ONLY_WHITELIST` on the
+notifier and label the containers you care about:
+
+```yaml
+services:
+  telegram-notifier:
+    environment:
+      ONLY_WHITELIST: true
+
+  example:
+    image: hello-world
+    labels:
+      telegram-notifier.monitor: true
+```
+
+<details>
+<summary>docker run</summary>
+
+```sh
+docker run -d --label telegram-notifier.monitor=true hello-world
+```
+
+</details>
+
+`ONLY_WHITELIST` counts as off when unset, empty, `false`, `0`, `no` or `off`.
+Any other value turns it on.

--- a/docs/remote-docker-and-proxy.md
+++ b/docs/remote-docker-and-proxy.md
@@ -1,0 +1,60 @@
+# Remote docker and proxies
+
+## Watching a remote daemon
+
+By default the notifier talks to the local docker socket, which means it goes
+down together with the host it is watching. Running it on a separate host
+avoids that blind spot.
+
+The usual `DOCKER_HOST` and `DOCKER_CERT_PATH` variables apply. For an HTTP
+endpoint, `DOCKER_HOST` is enough — keep such daemons behind a firewall. For
+HTTPS, also mount a directory containing `ca.pem`, `cert.pem` and `key.pem`:
+
+```yaml
+services:
+  telegram-notifier:
+    volumes:
+      # no socket mount at all for remote-only monitoring
+      - ./certs:/certs
+    environment:
+      DOCKER_HOST: tcp://example.com:2376 # http/https is detected by port number
+      DOCKER_CERT_PATH: /certs # should contain ca.pem, cert.pem, key.pem
+```
+
+Docker's own [guide to protecting the daemon
+socket](https://docs.docker.com/engine/security/https/) covers generating
+those certificates.
+
+## Outbound proxy
+
+If the host reaches the internet through a proxy, set `HTTPS_PROXY`:
+
+```yaml
+services:
+  telegram-notifier:
+    image: lorcas/docker-telegram-notifier:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      TELEGRAM_NOTIFIER_BOT_TOKEN: <bot_token>
+      TELEGRAM_NOTIFIER_CHAT_ID: <chat_id>
+      HTTPS_PROXY: http://proxy.example.com:8080
+```
+
+<details>
+<summary>docker run</summary>
+
+```sh
+docker run -d \
+  --env TELEGRAM_NOTIFIER_BOT_TOKEN=<bot_token> \
+  --env TELEGRAM_NOTIFIER_CHAT_ID=<chat_id> \
+  --env HTTPS_PROXY=http://proxy.example.com:8080 \
+  --volume /var/run/docker.sock:/var/run/docker.sock:ro \
+  lorcas/docker-telegram-notifier
+```
+
+</details>
+
+Lowercase `https_proxy` is accepted as well. This only affects the connection
+to Telegram — the docker socket is not reached over the network. An unusable
+proxy URL stops the container with exit code 100.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,0 +1,29 @@
+# Secrets
+
+Environment variables are readable by anyone who can run `docker inspect` on
+the container — a wider circle than it looks, given this container is usually
+the one holding the docker socket. To keep the bot token out of them, append
+`_FILE` to the variable name and point it at a file:
+
+```yaml
+services:
+  telegram-notifier:
+    image: lorcas/docker-telegram-notifier:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      TELEGRAM_NOTIFIER_BOT_TOKEN_FILE: /run/secrets/telegram_bot_token
+      TELEGRAM_NOTIFIER_CHAT_ID: <chat_id>
+    secrets:
+      - telegram_bot_token
+
+secrets:
+  telegram_bot_token:
+    file: ./telegram_bot_token.txt
+```
+
+`TELEGRAM_NOTIFIER_CHAT_ID_FILE` works the same way, and `_FILE` wins over the
+plain variable if both are set. A trailing newline in the file is ignored.
+
+If the file cannot be read, the container stops immediately with exit code 100
+and names the file it tried to open.

--- a/docs/securing-the-docker-socket.md
+++ b/docs/securing-the-docker-socket.md
@@ -1,0 +1,57 @@
+# Securing the docker socket
+
+The basic setup mounts the docker socket read-only:
+
+```yaml
+volumes:
+  - /var/run/docker.sock:/var/run/docker.sock:ro
+```
+
+**`:ro` protects the socket file, not the API behind it.** Anything that can
+reach the docker socket can create a container, mount any host path into it and
+run it as root — so it can take over the host, read-only mount or not. That
+applies to every tool that reads docker events this way, this one included.
+
+## Use a socket proxy
+
+This notifier needs four read-only endpoints: `version`, `info`, `ping` and
+`events`. A socket proxy is a small container that exposes exactly those and
+refuses everything else:
+
+```yaml
+services:
+  docker-socket-proxy:
+    image: tecnativa/docker-socket-proxy:latest
+    environment:
+      EVENTS: 1   # the event stream itself
+      INFO: 1     # host details in the start-up message
+      PING: 1     # the healthcheck's liveness probe
+      VERSION: 1  # docker version in the start-up message
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    restart: unless-stopped
+
+  telegram-notifier:
+    image: lorcas/docker-telegram-notifier:latest
+    depends_on:
+      - docker-socket-proxy
+    environment:
+      DOCKER_HOST: tcp://docker-socket-proxy:2375
+      TELEGRAM_NOTIFIER_BOT_TOKEN: <bot_token>
+      TELEGRAM_NOTIFIER_CHAT_ID: <chat_id>
+    restart: unless-stopped
+```
+
+The notifier gets no volume at all in this setup — it talks HTTP to the proxy,
+and the proxy is the only container holding the socket. Everything the proxy
+does not explicitly allow is refused, so a compromised notifier cannot create
+containers.
+
+Keep the proxy off any published port. It has no authentication, so anything
+that can reach it inherits its permissions.
+
+> [!NOTE]
+> This combination is tested: with those four permissions enabled and
+> everything else at its default of off, both notifications and the healthcheck
+> work. `PING` is easy to miss — the healthcheck uses it to tell a live daemon
+> from a stalled event stream.


### PR DESCRIPTION
The README had grown to 449 lines. This reduces it to 70 and moves everything past the quick start into `docs/`.

## What the README keeps

What the container does, one compose snippet, a table linking the nine documentation pages, and the docker-socket warning.

## New pages

| Page | Source |
| :--- | :--- |
| `basic-setup.md` | README §1 |
| `environment-variables.md` | **new** |
| `container-labels.md` | **new** |
| `filtering-containers.md` | README §2.2 + §2.3 |
| `chats-and-topics.md` | README §2.1 + §2.4 |
| `remote-docker-and-proxy.md` | README §2.5 + §2.7 |
| `secrets.md` | README §2.6 |
| `custom-templates.md` | README §3 |
| `securing-the-docker-socket.md` | README §4 |

The two reference tables are the reason for doing this at all — settings were previously spread over seven prose sections with no single place to look them up.

## Undocumented settings

Writing those tables surfaced two variables the code reads but nothing documented:

- `TELEGRAM_NOTIFIER_SEND_INTERVAL_MS` — minimum gap between messages, default 1000 (`telegram.js:18`)
- `TELEGRAM_NOTIFIER_HEARTBEAT_FILE` — path of the healthcheck's liveness marker (`app.js:81`)

Both are now in `docs/environment-variables.md`.

## Fixed references

The missing-configuration error printed a link to a `#1-basic-setup` anchor that this change removes, and `SECURITY.md` cited README sections by number. Both now point at the page they mean.

## Why `docs/` and not the wiki

The pages describe version-specific variables and the `templates.js` shipped in the image, so they should move with release tags and be reviewable alongside the code they document. A wiki lives in a separate repository with neither property.

Tests pass unchanged (38/38); no behaviour is touched apart from one error-message URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sm1qxeUY3vBeDNoiQB4s61