### PR TITLE
Mirror docs/ to the GitHub wiki

### DIFF
--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -1,0 +1,65 @@
+name: Sync wiki
+
+# The wiki is a mirror of docs/, never a source: it is rebuilt from scratch on
+# every run, so an edit made in the wiki UI survives only until the next push
+# to main. _Footer.md says as much on every page.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'scripts/build-wiki.js'
+      - '.github/workflows/wiki.yml'
+  workflow_dispatch:
+
+# Two pushes in quick succession would otherwise race for the same wiki
+# repository, and the loser fails on a non-fast-forward push.
+concurrency:
+  group: sync-wiki
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+
+      - name: Render docs/ into wiki pages
+        run: node scripts/build-wiki.js docs wiki
+
+      # GITHUB_TOKEN cannot push to the wiki repository — the wiki is not
+      # covered by the contents permission. Set a WIKI_TOKEN secret holding a
+      # personal access token with repository write access.
+      - name: Check out the wiki
+        run: |
+          if [ -z "${{ secrets.WIKI_TOKEN }}" ]; then
+            echo "::error::WIKI_TOKEN is not set. Create a personal access token with write access to this repository and add it as a repository secret named WIKI_TOKEN."
+            exit 1
+          fi
+          git clone \
+            "https://x-access-token:${{ secrets.WIKI_TOKEN }}@github.com/${{ github.repository }}.wiki.git" \
+            wiki-repo
+
+      - name: Publish
+        run: |
+          # Delete everything but .git so a page removed from docs/ also
+          # disappears from the wiki, then copy the freshly rendered set in.
+          find wiki-repo -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
+          cp wiki/*.md wiki-repo/
+
+          cd wiki-repo
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+
+          if git diff --cached --quiet; then
+            echo "Wiki already matches docs/, nothing to publish."
+            exit 0
+          fi
+
+          git commit -m "Sync docs/ from ${{ github.sha }}"
+          git push

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ That's it — every container on the host is reported from now on.
 | [Custom message templates](docs/custom-templates.md) | Rewriting the notification texts |
 | [Securing the docker socket](docs/securing-the-docker-socket.md) | Why `:ro` is not enough, and what to do instead |
 
+The same pages are mirrored to the [wiki](https://github.com/luc-ass/docker-telegram-notifier/wiki), which is generated from `docs/` — edit them there and the next sync overwrites you.
+
 > [!WARNING]
 > Mounting the docker socket read-only protects the socket file, not the API
 > behind it — anything that reaches it can take over the host. See

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,8 @@
 # Documentation
 
+Everything beyond the quick start in the
+[README](https://github.com/luc-ass/docker-telegram-notifier#readme).
+
 | Page | What it covers |
 | :--- | :--- |
 | [Basic setup](basic-setup.md) | Create the bot, run the container, add a healthcheck |

--- a/scripts/build-wiki.js
+++ b/scripts/build-wiki.js
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/**
+ * Renders docs/ into the flat page layout a GitHub wiki expects.
+ *
+ * The wiki lives in its own repository, so it cannot follow the relative
+ * links docs/ uses: `securing-the-docker-socket.md` has to become
+ * `Securing-the-Docker-Socket`, and anything pointing outside docs/ has to
+ * become an absolute URL into the code repository.
+ *
+ * Page order comes from the table in docs/README.md rather than the
+ * filesystem, so the sidebar keeps the order a reader was meant to see and a
+ * new page is picked up by adding it to that table.
+ *
+ * Usage: node scripts/build-wiki.js [docs] [outdir]
+ */
+const fs = require('fs');
+const path = require('path');
+
+const [, , docsDir = 'docs', outDir = 'wiki'] = process.argv;
+
+const REPO = 'https://github.com/luc-ass/docker-telegram-notifier';
+const BLOB = `${REPO}/blob/main`;
+
+// Words a title case leaves alone, so `chats-and-topics` reads as
+// "Chats and Topics" rather than "Chats And Topics".
+const SMALL_WORDS = new Set(['a', 'an', 'and', 'as', 'at', 'for', 'from',
+  'in', 'of', 'on', 'or', 'the', 'to', 'via', 'with']);
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+/** docs/basic-setup.md -> Basic-Setup, docs/README.md -> Home */
+function pageName(file) {
+  const base = path.basename(file, '.md');
+  if (base === 'README') return 'Home';
+
+  return base.split('-')
+    .map((word, i) => i > 0 && SMALL_WORDS.has(word) ?
+      word : word.charAt(0).toUpperCase() + word.slice(1))
+    .join('-');
+}
+
+function read(file) {
+  try {
+    return fs.readFileSync(file, 'utf8');
+  } catch (e) {
+    fail(`Could not read ${file}: ${e.message}`);
+  }
+}
+
+/**
+ * The order of the documentation table in docs/README.md, which doubles as
+ * the list of pages worth syncing. A page missing from it would end up in the
+ * wiki with no way to navigate to it, so that is an error rather than a
+ * default to alphabetical.
+ */
+function orderedPages(index) {
+  const linked = [...index.matchAll(/\]\(([a-z0-9-]+\.md)\)/g)].map(m => m[1]);
+  const onDisk = fs.readdirSync(docsDir)
+    .filter(f => f.endsWith('.md') && f !== 'README.md');
+
+  const missing = onDisk.filter(f => !linked.includes(f));
+  if (missing.length > 0) {
+    fail(`Not listed in ${docsDir}/README.md, so unreachable in the wiki: ` +
+      missing.join(', '));
+  }
+
+  return linked;
+}
+
+/**
+ * Relative links are the whole reason this script exists: the wiki resolves
+ * them against its own flat namespace, so every one of them has to be
+ * rewritten or turned into an absolute URL.
+ */
+function rewriteLinks(body, file, pages) {
+  return body.replace(/\]\((?!https?:)([^)]+)\)/g, (match, target) => {
+    const [target_, anchor = ''] = target.split(/(#.*)$/);
+    const suffix = anchor;
+
+    if (target_.startsWith('../')) {
+      return `](${BLOB}/${target_.slice(3)}${suffix})`;
+    }
+
+    if (target_.endsWith('.md')) {
+      if (!pages.includes(target_) && target_ !== 'README.md') {
+        fail(`${file} links to ${target_}, which is not a wiki page`);
+      }
+      return `](${pageName(target_)}${suffix})`;
+    }
+
+    // A bare anchor stays put; anything else points at a repository file.
+    return target_ === '' ? match : `](${BLOB}/${target_}${suffix})`;
+  });
+}
+
+const index = read(path.join(docsDir, 'README.md'));
+const pages = orderedPages(index);
+
+fs.rmSync(outDir, { recursive: true, force: true });
+fs.mkdirSync(outDir, { recursive: true });
+
+for (const file of ['README.md', ...pages]) {
+  const body = rewriteLinks(read(path.join(docsDir, file)), file, pages);
+  fs.writeFileSync(path.join(outDir, `${pageName(file)}.md`), body);
+}
+
+const sidebar = pages
+  .map(file => `- [${pageName(file).replace(/-/g, ' ')}](${pageName(file)})`)
+  .join('\n');
+
+fs.writeFileSync(path.join(outDir, '_Sidebar.md'),
+  `### [Documentation](Home)\n\n${sidebar}\n`);
+
+fs.writeFileSync(path.join(outDir, '_Footer.md'),
+  `_Generated from [\`docs/\`](${BLOB}/docs) — edits made here are ` +
+  `overwritten by the next sync. Open a pull request against the ` +
+  `repository instead._\n`);
+
+console.log(`Wrote ${pages.length + 3} pages to ${outDir}/`);


### PR DESCRIPTION
Stacked on #157 — merge that one first and GitHub retargets this to `main`.

Mirrors `docs/` into the wiki and keeps it there automatically.

## `scripts/build-wiki.js`

The wiki is a separate repository with a flat namespace, so the relative links in `docs/` do not resolve there. The script rewrites them:

- `securing-the-docker-socket.md` → `Securing-the-Docker-Socket`
- `../templates.js` → an absolute blob URL into this repository
- `docs/README.md` → `Home.md`

It also generates `_Sidebar.md` and a `_Footer.md` that tells readers the pages are generated.

Page order comes from the table in `docs/README.md`, not from the filesystem, so the sidebar keeps the curated order. A page missing from that table fails the build rather than silently landing in the wiki with nothing linking to it.

## `.github/workflows/wiki.yml`

Runs on pushes to `main` that touch `docs/**`, the script, or the workflow, plus `workflow_dispatch`. The wiki is rebuilt from scratch each run, so a deleted page also disappears. A concurrency group prevents two pushes racing for the same repository.

**Needs a `WIKI_TOKEN` secret.** `GITHUB_TOKEN` cannot push to a wiki — the wiki is not covered by the `contents` permission. The job checks for the secret and says so, rather than failing on an opaque 403.

## Already live

I ran the same sequence by hand, so the wiki is populated now: https://github.com/luc-ass/docker-telegram-notifier/wiki — all nine pages return 200 and every internal link resolves.

Tests pass (38/38); no application code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sm1qxeUY3vBeDNoiQB4s61